### PR TITLE
Prepare for renaming of FastJetClustering package

### DIFF
--- a/builds/release-versions-HEAD.py
+++ b/builds/release-versions-HEAD.py
@@ -59,8 +59,6 @@ ILCUTIL_version = "HEAD"
 
 FastJet_version = "HEAD"
 
-FastJetClustering_version = "HEAD" #"v00-02"
-
 MarlinFastJet_version = "HEAD" # "v00-02"
 
 

--- a/ilcsoft/fastjet.py
+++ b/ilcsoft/fastjet.py
@@ -25,7 +25,7 @@ class FastJetClustering(MarlinPKG):
 
         self.download.supportedTypes = [ "GitHub" ] 
         self.download.gituser = 'iLCSoft'
-        self.download.gitrepo = 'FastJetClustering'
+        self.download.gitrepo = 'obsolete_FastJetClustering'
 
 
 class FastJet(BaseILC):

--- a/nightly_builds/release-versions.py
+++ b/nightly_builds/release-versions.py
@@ -165,8 +165,6 @@ ILCUTIL_version = "v01-03-pre"  #  "v01-02-01"
 
 FastJet_version = "3.1.2"
 
-FastJetClustering_version = "HEAD" #"v00-02"
-
 MarlinFastJet_version = "HEAD" # "v00-02"
 
 

--- a/nightly_builds/sl5_64bit-nb_debug.cfg
+++ b/nightly_builds/sl5_64bit-nb_debug.cfg
@@ -101,9 +101,6 @@ ilcsoft.install( MarlinTPC( "HEAD" ))
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='trunk'
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='tags/V03-03-00'
 
-
-ilcsoft.install( FastJetClustering( "HEAD" ))
-
 ilcsoft.install( MarlinPKG( "MarlinFastJet", "HEAD" ))
 ilcsoft.module("MarlinFastJet").download.root="marlinreco"
 ilcsoft.module("MarlinFastJet").addDependency( [ 'LCIO', 'Marlin', 'FastJet'] )

--- a/nightly_builds/sl6-c++11_nb_debug.cfg
+++ b/nightly_builds/sl6-c++11_nb_debug.cfg
@@ -116,7 +116,6 @@ ilcsoft.install( MarlinTPC( "HEAD" ))
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='tags/V03-03-00'
 
 
-ilcsoft.install( FastJetClustering( "HEAD" ))
 
 ilcsoft.install( MarlinPKG( "MarlinFastJet", "HEAD" ))
 ilcsoft.module("MarlinFastJet").download.root="marlinreco"

--- a/nightly_builds/sl6-nb_debug.cfg
+++ b/nightly_builds/sl6-nb_debug.cfg
@@ -109,9 +109,6 @@ ilcsoft.install( MarlinTPC( "HEAD" ))
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='trunk'
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='tags/V03-03-00'
 
-
-ilcsoft.install( FastJetClustering( "HEAD" ))
-
 ilcsoft.install( MarlinPKG( "MarlinFastJet", "HEAD" ))
 ilcsoft.module("MarlinFastJet").download.root="marlinreco"
 ilcsoft.module("MarlinFastJet").addDependency( [ 'LCIO', 'Marlin', 'FastJet'] )

--- a/nightly_builds/ubuntu14.04-nb_debug.cfg
+++ b/nightly_builds/ubuntu14.04-nb_debug.cfg
@@ -99,7 +99,6 @@ ilcsoft.install( MarlinTPC( "HEAD" ))
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='tags/V03-03-00'
 
 
-ilcsoft.install( FastJetClustering( "HEAD" ))
 
 ilcsoft.install( MarlinPKG( "MarlinFastJet", "HEAD" ))
 ilcsoft.module("MarlinFastJet").download.root="marlinreco"

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -132,8 +132,6 @@ ilcsoft.install( CEDViewer( CEDViewer_version ))
 
 ilcsoft.install( Overlay( Overlay_version ))  
 
-ilcsoft.install( FastJetClustering( FastJetClustering_version ))
-
 ilcsoft.install( MarlinPKG( "MarlinFastJet", MarlinFastJet_version ))
 ilcsoft.module("MarlinFastJet").addDependency( [ 'LCIO', 'Marlin', 'FastJet'] )
 

--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -145,8 +145,6 @@ ILCUTIL_version = "v01-03"  #  "v01-02-01"
 FastJet_version = "3.2.0"
 FastJetcontrib_version = "1.024"
 
-FastJetClustering_version = "HEAD" #"v00-02"
-
 MarlinFastJet_version = "HEAD" # "v00-02"
 
 

--- a/releases/v01-19/release-ilcsoft.cfg
+++ b/releases/v01-19/release-ilcsoft.cfg
@@ -135,8 +135,6 @@ ilcsoft.install( CEDViewer( CEDViewer_version ))
 
 ilcsoft.install( Overlay( Overlay_version ))  
 
-ilcsoft.install( FastJetClustering( FastJetClustering_version ))
-
 ilcsoft.install( MarlinPKG( "MarlinFastJet", MarlinFastJet_version ))
 ilcsoft.module("MarlinFastJet").addDependency( [ 'LCIO', 'Marlin', 'FastJet'] )
 

--- a/releases/v01-19/release-versions.py
+++ b/releases/v01-19/release-versions.py
@@ -145,8 +145,6 @@ ILCUTIL_version = "v01-03" # "v01-04"
 FastJet_version = "3.2.0"
 FastJetcontrib_version = "1.024"
 
-FastJetClustering_version = "v00-03" 
-
 MarlinFastJet_version = "v00-03" 
 
 


### PR DESCRIPTION
in order to rename the FastJetClustering repo to `obsolete_FastJetClustering` and not break the nightly builds or new installations of last release.

 * removed from nightly builds
 * changed location in ilcsoft/fastjet.py module for installation of existing tags

When this PR is merged I will rename the repository

BEGINRELEASENOTES
- Removed FastJetClustering from installed packages, because the processor was merged into the MarlinFastJet package

ENDRELEASENOTES
