### PR TITLE
Add ilcsofttagging script to create releases for github packages

### DIFF
--- a/scripts/ilcsofttagger.py
+++ b/scripts/ilcsofttagger.py
@@ -1,0 +1,231 @@
+#!/bin/env python
+"""
+
+Tagging System for iLCSoft libraries. Make tags, collate release notes via command line or steering file
+
+
+owner, repository, branch, tag (optional), createReleaseNotes(bool), prerelease(bool)
+
+"""
+
+from logging import getLogger
+import logging
+from pprint import pprint
+
+import argparse
+
+__RCSID__ = None
+
+from tagging.gitinterface import Repo
+from tagging.helperfunctions import checkRate
+
+def _parsePrintLevel( level ):
+  """ translate printlevel to logging level"""
+  return dict( CRITICAL=logging.CRITICAL,
+               ERROR=logging.ERROR,
+               WARNING=logging.WARNING,
+               INFO=logging.INFO,
+               DEBUG=logging.DEBUG,
+             )[level]
+
+class ILCSoftTagger(object):
+  """ object to hold the interface to make tags, read command line options, etc"""
+
+  def __init__( self ):
+    self.configFile = None
+    self.printLevel = "INFO"
+    self.packages = []
+    self.repos = []
+    self.makeTags = False
+    self.properRelease = False
+    self.errors = []
+    self.log = getLogger( "Tagger" )
+
+  def abort( self ):
+    """ print error messages and raise exception """
+    for line in self.errors:
+      self.log.error( "ERROR: %s", line )
+    raise RuntimeError( "ERROR" )
+
+  def parseOptions(self):
+    """parse the command line options"""
+    parser = argparse.ArgumentParser("Makking ILCSoft Tags",
+                                     formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument("--file", action="store", default=self.configFile, dest="configFile",
+                        help="file holding packages to tag")
+
+    parser.add_argument("-v", "--printLevel", action="store", default=self.printLevel, dest="printLevel",
+                        choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
+                        help="Verbosity DEBUG, INFO, WARNING, ERROR, CRITICAL")
+
+    parser.add_argument("--packages", action="store", default=self.packages, nargs='+',
+                        help="packages to check: [owner/]package[/version[/branch]]")
+
+    parser.add_argument("--makeTags", action="store_true", dest="makeTags", default=self.makeTags,
+                        help="Create the tags, commit release notes")
+
+    parser.add_argument("--properRelease", action="store_true", dest="properRelease", default=self.properRelease,
+                        help="if set make proper release, if not set make pre release only")
+
+
+    parser.add_argument("--checkRate", action="store_true", dest="checkRate", default=False,
+                        help="Print out remaining number of queries for this hour")
+
+
+    parsed = parser.parse_args()
+
+    self.configFile = parsed.configFile
+    self.printLevel = _parsePrintLevel( parsed.printLevel )
+    logging.basicConfig( level=self.printLevel, format='%(levelname)-5s - %(name)-8s: %(message)s' )
+
+    self.packages = parsed.packages
+    self.makeTags = parsed.makeTags
+    self.properRelease = parsed.properRelease
+
+    self._parseConfigFile()
+
+    if parsed.checkRate:
+      checkRate()
+
+    if self.errors:
+      self.abort()
+
+  def _printVersionsFile( self ):
+    """ print the versions.cfg file to be used in ilcsoft-install config files"""
+    self.log.info( "New version configuration:")
+    versionsContent = ""
+    for package in self.repos:
+      versionsContent += '\n%s_version = "%s" ' % ( package.repo, package.newTag )
+
+    print "*"*80
+    print versionsContent
+    print "*"*80
+
+
+  def _parseConfigFile( self ):
+    """ parses the config file and files packages list"""
+    if self.configFile is None:
+      return
+
+
+    with open(self.configFile) as conf:
+      for line in conf.readlines():
+        if not line.strip():
+          continue
+        parts = line.strip().split(" ")
+        if len(parts) != 1:
+          self.errors.append( "Line '%s' cannot be parsed" % line.strip() )
+        else:
+          self.packages.append( line.strip() )
+
+    return
+
+
+  def parsePackage( self, packageString ):
+    """ return tuple of owner, repo, branch, version
+
+    default owner: ilcsoft
+    default branch: master
+    default version: None
+    """
+    slashCount = packageString.count('/')
+    if slashCount == 0:
+      owner = "iLCSoft"
+      package = packageString
+      version=None
+      branch='master'
+    elif slashCount == 1:
+      owner = packageString.split('/')[0]
+      package = packageString.split('/')[1]
+      version=None
+      branch='master'
+    elif slashCount == 2:
+      owner = packageString.split('/')[0]
+      package = packageString.split('/')[1]
+      version = packageString.split('/')[2]
+      branch='master'
+    elif slashCount == 3:
+      owner = packageString.split('/')[0]
+      package = packageString.split('/')[1]
+      version = packageString.split('/')[2]
+      branch = packageString.split('/')[3]
+
+    self.log.debug( "Added package: %s %s %s %s", owner, package, branch, version )
+    return owner, package, branch, version
+
+  def _printReleaseNotes( self ):
+    """ print release notes for all packages """
+    for thisPackage in self.repos:
+      if thisPackage.isUpToDate():
+        continue
+      separateString = "*"*80
+      if self.makeTags:
+        self.log.info( "Create new release for %s: %s", thisPackage.repo, thisPackage.newTag )
+      else:
+        self.log.info( "Dry Run for new %s release: %s", thisPackage.repo, thisPackage.newTag )
+      self.log.info( "Release notes for %s:\n%s\n%s\n%s",
+                     thisPackage,
+                     separateString,
+                     thisPackage.formatReleaseNotes(),
+                     separateString, )
+
+
+  def _commitAndTag( self ):
+    """ commit release notes and updated versions settings and make release """
+    for package in self.repos:
+      if package.isUpToDate():
+        self.log.info( "Package %s has no updates since last tag", package )
+        continue
+      self.log.info( "Committing release notes for: %s", package )
+      package.commitNewReleaseNotes()
+      self.log.info( "Updating version: %s to %s", package, package.newVersion )
+      package.updateVersionSettings()
+      package.createGithubRelease()
+
+
+  def run( self ):
+    """ execute everything """
+    for package in self.packages:
+      self.log.info( "Checking package: %s", package )
+      owner, package, branch, version = self.parsePackage( package )
+      prerelease = not self.properRelease
+      try:
+        dryRun = not self.makeTags
+        thisPackage = Repo( owner, package, branch=branch, newVersion=version, preRelease=prerelease, dryRun=dryRun)
+      except RuntimeError as e:
+        self.log.error( "Failure for %s", thisPackage )
+        self.errors.append( str(e) )
+      self.repos.append( thisPackage )
+
+    if self.errors:
+      self.abort()
+      
+    self._printReleaseNotes()
+    self._commitAndTag()
+
+    
+    self._printVersionsFile()
+    checkRate()
+
+
+if __name__ == "__main__":
+  #logging.basicConfig( level=logging.INFO)
+  RUNNER = ILCSoftTagger()
+  try:
+    RUNNER.parseOptions()
+  except RuntimeError as e:
+    print ("Error during runtime: %s", e)
+    exit(1)
+
+  try:
+    RUNNER.run()
+  except RuntimeError as e:
+    logging.error("Error during runtime: %s", e)
+    exit(1)
+
+
+### Get list of tags, get latest tag, get all PRs merged after this date, get
+### comments for this PR, parse comments for "Relase Notes" and collate them
+### into release notes for the pacakge, add commit with release notes, add
+### commit with new version, ignore pre-release tags for collating release notes

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -1,0 +1,513 @@
+"""
+interface to github via CURL
+
+"""
+
+import json
+from logging import getLogger
+from collections import OrderedDict, defaultdict
+import re
+
+from pprint import pprint
+from operator import itemgetter
+
+from helperfunctions import parseForReleaseNotes, getCommands, curl2Json, \
+                            authorMapping, ghHeaders, versionComp
+from parseversion import Version
+
+__RCSID__ = None
+
+class Repo(object):
+  """ class representing a given repository"""
+
+  def __init__( self, owner, repo, branch='master', newVersion=None, preRelease=True, dryRun=True):
+    self.owner = owner
+    self.repo = repo
+    self.branch = branch
+    self._options = dict( owner=self.owner, repo=self.repo  )
+    self.log = getLogger( repo )
+    self.latestTagInfo = None
+    self._releaseNotes = None
+    self.releaseNotesFilename = "doc/ReleaseNotes.md"
+    self.cmakeBaseFile = "CMakeLists.txt"
+    self._lastCommitOnBranch = None
+    self._prsSinceLastTag = None
+    ## members dealing with difference between the new full version and the next
+    ## tag which can be different because of pre-prereleaseness
+    self.isPreRelease = preRelease
+    self._newVersion = None
+    self.newVersion = newVersion
+    self._version = None
+    self._setNewVersion()
+    self._dryRun = dryRun
+
+  def __str__( self ):
+    return self.owner+"/"+self.repo
+
+  @property
+  def newTag( self ):
+    """ return next tag version, differs from newversion by pre release """
+    return str( self._version )
+
+  @newTag.setter
+  def newTag( self, val):
+    """ cannot set this property """
+    raise NotImplementedError( "not allowed to change newTag, user 'newVersion' instead ")
+
+  @property
+  def newVersion( self ):
+    """ return new version """
+    if self._newVersion is not None:
+      return self._newVersion
+
+    self._setNewVersion()
+    return self._newVersion
+
+  @newVersion.setter
+  def newVersion( self, val ):
+    """ set newVersion to value"""
+    if val is None:
+      self._setNewVersion()
+    else:
+      self._newVersion = str(val)
+
+  def _setNewVersion( self ):
+    """ get the new version based on the previous tag, increment patch version"""
+    if self._newVersion is not None:
+      self._version = Version(self._newVersion, makePreRelease=self.isPreRelease )
+      return str( self._version )
+    lastVersion = self._getLatestTagInfo()['name']
+    self._version = Version(lastVersion, makePreRelease=self.isPreRelease )
+    self._version.increment()
+    self._newVersion = str( self._version )
+    self.log.info( "Set new version: %s", self._newVersion )
+
+  def _getLatestTagInfo( self ):
+    """ fill the information about the latest tag in the repository, ignore pre commit tags"""
+    if self.latestTagInfo is not None:
+      self.log.debug( "Latest Tag Info already filled" )
+      return self.latestTagInfo ## already filled
+    tags = self.getGithubTags()
+    sortedTags = sorted(tags, key=itemgetter("name"), reverse=True, cmp=versionComp)
+    for di in sortedTags:
+      self.latestTagInfo = di
+      self.latestTagInfo['pre'] = True if 'pre' in di['name'] else False
+      self.latestTagInfo['sha'] = di['commit']['sha']
+      self.log.info( "Found latest tag %s", di['name'] )
+      break
+
+    if not tags:
+      self.log.warning( "No tags found for %s", self )
+      self.latestTagInfo={}
+      self.latestTagInfo['date'] = "1977-01-01T"
+      self.latestTagInfo['sha'] = "SHASHASHA"
+      self.latestTagInfo['name'] = "00-00"
+    else:
+      commitInfo = curl2Json( ghHeaders(), self._github( "git/commits/%s" % self.latestTagInfo['sha'] ) )
+      self.latestTagInfo['date'] = commitInfo['committer']['date']
+
+    lastCommitInfo = curl2Json( ghHeaders(), self._github( "branches/%s" % self.branch ) )
+    self._lastCommitOnBranch =  lastCommitInfo['commit']
+
+    # tags = self.getGithubReleases()
+    # for di in sorted(tags, key=itemgetter('created_at') ):
+    #   self.latestTagInfo = di
+    #   self.latestTagInfo['pre'] = di['prerelease']
+    #   self.latestTagInfo['date'] = di['created_at']
+    #   self.log.info( "Found latest tag %s", di['name'] )
+    #   break
+
+    return self.latestTagInfo
+
+
+  def _github( self, action ):
+    """ return the url to perform actions on github
+
+    :param str action: command to use in the gitlab API, see documentation there
+    :returns: url to be used by curl
+    """
+    options = dict(self._options)
+    options["action"] = action
+    ghURL = "https://api.github.com/repos/%(owner)s/%(repo)s/%(action)s" % options
+    return ghURL
+
+
+  def getGithubPRs( self, state="open", mergedOnly=False, perPage=100):
+    """ get all PullRequests from github
+
+    :param str state: state of the PRs, open/closed/all, default open
+    :param bool merged: if PR has to be merged, only sensible for state=closed
+    :returns: list of githubPRs
+    """
+    url = self._github( "pulls?state=%s&per_page=%s" % (state, perPage) )
+    prs = curl2Json( ghHeaders(), url )
+    #pprint(prs)
+    if not mergedOnly:
+      return prs
+
+    ## only merged PRs
+    prsToReturn = []
+    for pr in prs:
+      if pr.get( 'merged_at', None ) is not None:
+        prsToReturn.append(pr)
+
+    return prsToReturn
+
+  def getGithubTags( self):
+    """ get all tags from github
+
+    u'commit': {u'sha': u'49680c32f9c0734dcbf0efe2f01e2363dab3c64e',
+                u'url': u'https://api.github.com/repos/andresailer/Marlin/commits/49680c32f9c0734dcbf0efe2f01e2363dab3c64e'},
+    u'name': u'v01-02-01',
+    u'tarball_url': u'https://api.github.com/repos/andresailer/Marlin/tarball/v01-02-01',
+    u'zipball_url': u'https://api.github.com/repos/andresailer/Marlin/zipball/v01-02-01'},
+
+    :returns: list of tags
+    """
+    result = curl2Json( ghHeaders(), self._github( "tags" ) )
+    if isinstance( result, dict ) and 'Not Found' in result.get('message'):
+      raise RuntimeError( "Package not found: %s" % str(self) )
+    return result
+
+  def getGithubReleases( self):
+    """ get the last few releases from github
+
+    :returns: list of releases
+    """
+    result = curl2Json( ghHeaders(), self._github( "releases" ) )
+    #pprint(result)
+    return result
+
+
+  def getHeadOfBranch( self ):
+    """return the commit sha of the head of the branch"""
+    result = curl2Json( ghHeaders(),
+                        self._github( "git/refs/heads/%s" % self.branch )
+                      )
+    if 'message' in result:
+      raise RuntimeError( "Error:",result['message'] )
+
+    commitsha = result['object']['sha']
+
+    return commitsha
+    ## also get the sha of the tree
+
+  def getTreeShaForCommit( self, commit ):
+    """ return the sha of the tree for given commit"""
+    result = curl2Json( ghHeaders(),
+                        self._github( "git/commits/%s" % commit )
+                      )
+    if 'sha' not in result:
+      raise RuntimeError( "Error: Commit not found" )
+    treesha = result['tree']['sha']
+    return treesha
+
+  # def createGithubTag( self ):
+  #   """
+  #   create a tag on the repository with `version` and on `branch`, makes tag on last commit of the branch
+  #   """
+  #   message = "New tag %s" % self.newVersion
+  #   prDict = dict( branch=self.branch, version=self.newVersion, message=message,
+  #                  gtype="commit"
+  #                )
+
+  #   prDict['sha'] = self.getHeadOfBranch()
+  #   if self._dryRun:
+  #     self.log.info( "DryRun: not actually making tag: %s", prDict )
+  #     return {}
+
+  #   result = curl2Json( ghHeaders(),
+  #                       '-d { "tag": "%(version)s", "message": "%(message)s", "object":"%(sha)s", "type":"%(gtype)s" '% prDict ,
+  #                       self._github( "git/tags" ) )
+  #   #pprint(result)
+
+  #   #FIXME: error message is actually different
+  #   if 'errors' in result:
+  #     for error in result['errors']:
+  #       self.log.error( "ERROR creating Tag: %s", error['message'] )
+  #     return False
+
+  #   prDict['tagSha'] = result['sha']
+
+  #   result = curl2Json( ghHeaders(),
+  #                       '-d { "ref": "refs/tags/%(version)s", "sha": "%(tagSha)s" '% prDict ,
+  #                       self._github( "git/refs" ) )
+  #   self.log.info( "New tag created" )
+  #   return result
+
+  def createGithubRelease( self ):
+    """ make a release on github """
+    if self.isUpToDate():
+      self.log.warning( "Package %s is up to date, will not make new release", self )
+      return
+
+
+    releaseDict = dict( tag_name=self.newVersion,
+                        target_commitish=self.branch,
+                        name=self.newTag,
+                        body=self.formatReleaseNotes(),
+                        prerelease=self.isPreRelease,
+                      )
+    if self._dryRun:
+      self.log.info( "DryRun: not actually making Release: %s", releaseDict )
+      return {}
+    result = curl2Json( ghHeaders(), self._github( "releases" ),
+                        '-d %s ' % json.dumps( releaseDict )
+                      )
+    #pprint(result)
+    return result
+
+
+
+  def isPRMerged( self, prID ):
+    """ returns True/False wether the PR has been merged or not
+
+    :param int prID: ID of the pull request
+    :returns: True/False
+    """
+    result = curl2Json( ghHeaders(), self._github( "pulls/%d/merge" %prID ), checkStatusOnly=True )
+    for line in result.splitlines():
+      if "Status" in line:
+        if "204" in line:
+          self.log.debug( "PR %d is merged", prID)
+          return True
+        else:
+          self.log.debug( "PR %d is NOT merged", prID)
+          return False
+    return False
+
+
+  def _getPRsSinceLatestTag( self ):
+    """ return the PRs since the last tag """
+    self._getLatestTagInfo()
+    if self.isUpToDate():
+      return
+
+    mergedPRs = self.getGithubPRs( state="closed", mergedOnly=True )
+    #pprint(mergedPRs)
+    lastTagDate = self.latestTagInfo['date']
+    self.log.info( "Last tag was done: %s ", lastTagDate )
+
+    self._prsSinceLastTag = []
+
+    self.log.info( "Getting PRs...")
+    for pr in mergedPRs:
+      if pr['merged_at'] > lastTagDate:
+        self.log.debug( "PR %s was merged _AFTER_ the last tag", pr['number'] )
+        self._prsSinceLastTag.append(pr)
+      else:
+        self.log.debug( "PR %s was merged _BEFORE_ the last tag", pr['number'] )
+    if self._prsSinceLastTag:
+      self.log.info( "... PRs merged after Tag: %s", ", ".join( sorted(str( pr['number'] ) for pr in self._prsSinceLastTag )) )
+    return
+
+  def getCommentsForPR( self, prID ):
+    """get the comments for a PR
+
+    :param int prID: pull request ID to get the comments from
+    :returns: list of comments
+    """
+    self.log.debug( "Getting comments for PR %s", prID )
+    comments = curl2Json( ghHeaders(), self._github("issues/%s/comments" %prID  ) )
+    commentTexts = []
+    for comment in comments:
+      commentTexts.append( comment['body'] )
+
+    return commentTexts
+
+  def getAuthorForPR( self, pr ):
+    """ return the author name of given PR, check cache if username already known """
+    username = pr['user']['login']
+    prID = pr['number']
+    commands = list(ghHeaders()) + [ self._github( "pulls/%s/commits" % prID ) ]
+    authorName = authorMapping( username, commands )
+    return authorName
+    
+    
+  def _getReleaseNotes( self ):
+    """ parses the PRs and comments for ReleaseNotes to collate them  """
+    if self._prsSinceLastTag is None:
+      self._getPRsSinceLatestTag()
+    if not self._prsSinceLastTag:
+      self._releaseNotes = defaultdict( OrderedDict )
+      self.log.info( "No PRs found" )
+      return
+
+    relNotes = defaultdict( OrderedDict )
+    self.log.info( "Getting release notes from PR comments ... ")
+    for pr in self._prsSinceLastTag:
+      prID = pr['number']
+      self.log.debug( "Looking for comments for PR %s", prID )
+      date = pr['merged_at'][:10] ## only YYYY-MM-DD
+      author = self.getAuthorForPR( pr )
+      relNotes[date][prID] = dict( author=author, notes=[], date=pr['merged_at'], prID=pr['number'] )
+
+      notes = parseForReleaseNotes( pr['body'] )
+      if notes:
+        relNotes[date][prID]['notes'].extend( notes )
+      commentTexts = self.getCommentsForPR( prID )
+      for comment in commentTexts:
+        notes = parseForReleaseNotes( comment )
+        if notes:
+          relNotes[date][prID]['notes'].extend( notes )
+    self._releaseNotes = relNotes
+    self.log.info( "... finished getting release notes" )
+    return
+
+  def formatReleaseNotes( self ):
+    """ print the release notes """
+    if self._releaseNotes is None and not self.isUpToDate():
+      self._getReleaseNotes()
+
+    if self.isUpToDate():
+      return
+
+    releaseNotesString = "# " + self.newVersion.split("-pre")[0] ## never write comments for new releases
+
+    for date, prs in self._releaseNotes.iteritems():
+      for prID,content in prs.iteritems():
+        if not content.get( 'notes' ):
+          continue
+
+        for line in content['notes']:
+          thisContent = line.strip()
+          indentedContent = "  " + "\n  ".join(thisContent.split("\n"))
+          relNoteDict = dict( author=content['author'],
+                              prLink="[PR#%s](https://github.com/%s/%s/pull/%s)" % (prID, self.owner, self.repo, prID ),
+                              date=date,
+                              content=indentedContent.rstrip(),
+                            )
+          releaseNotesString += """
+
+* %(date)s %(author)s (%(prLink)s)
+%(content)s""" % relNoteDict
+
+    ## cleanup "\r" from strings
+    releaseNotesString = releaseNotesString.replace("\r","")
+    return releaseNotesString
+
+
+  def commitNewReleaseNotes( self ):
+    """ get the new release notes and commit them to the filename """
+    content, sha, encodedOld= self.getFileFromBranch( self.releaseNotesFilename )
+    if self.latestTagInfo['pre']:
+      content = "\n".join(content.split("\n")[2:]) ## remove first line which is the release name
+    contentNew = self.formatReleaseNotes() + "\n\n" + content
+    
+    contentEncoded = contentNew.encode('base64')
+
+    if encodedOld.replace("\n","") == contentEncoded.replace("\n",""):
+      self.log.info("No changes in %s, not making commit", self.releaseNotesFilename )
+      return
+    message = "Release Notes for %s" % self.newVersion
+    self.createGithubCommit(self.releaseNotesFilename, sha, contentEncoded, message=message)
+
+
+  def getFileFromBranch( self, filename ):
+    """return the content of the file in the given branch, filename needs to be the full path"""
+
+    result = curl2Json( ghHeaders(), self._github( "contents/%s?branch=%s" %(filename,self.branch) ) )
+    encoded = result.get( 'content', None )
+    if encoded is None:
+      self.log.error( "File %s not found for %s", filename, self )
+      raise RuntimeError( "File not found" )
+    content = encoded.decode("base64")
+    sha = result['sha']
+    return content, sha, encoded
+
+  def updateVersionSettings( self ):
+    """ get the new release notes and commit them to the filename """
+
+    content, sha, encodedOld = self.getFileFromBranch( self.cmakeBaseFile )
+    major, minor, patch = self._version.getMajorMinorPatch()
+    pMajor = re.compile('_VERSION_MAJOR [0-9]*')
+    pMinor = re.compile('_VERSION_MINOR [0-9]*')
+    pPatch = re.compile('_VERSION_PATCH [0-9]*')
+    content = pMajor.sub( "_VERSION_MAJOR %s" % major, content )
+    content = pMinor.sub( "_VERSION_MINOR %s" % minor, content )
+    content = pPatch.sub( "_VERSION_PATCH %s" % patch, content )
+    contentEncoded = content.encode('base64')
+    if encodedOld.replace("\n","") == contentEncoded.replace("\n",""):
+      self.log.info("No changes in %s, not making commit", self.cmakeBaseFile )
+      return
+
+    message = "Updating version to %s" % self.newVersion
+    self.createGithubCommit(self.cmakeBaseFile, sha, contentEncoded, message=message)
+
+
+
+  def createGithubCommit( self, filename, fileSha, content, message ):
+    """
+    create a commit on the repository with `version` and on `branch`, makes tag on last commit of the branch
+
+    :param str treeSha: sha of the tree the commit will go
+    :param str filename: full path to the file
+    :param str content: base64 encoded content of the file
+
+
+    PUT /repos/:owner/:repo/contents/:path
+
+    Parameters
+    Name  Type  Description
+    path  string  Required. The content path.
+    message   string  Required. The commit message.
+    content   string  Required. The updated file content, Base64 encoded.
+    sha   string  Required. The blob SHA of the file being replaced.
+    branch  string  The branch name. Default: the repository's default branch (usually master)
+    Optional Parameters
+
+    """
+    coDict = dict( path=filename, content=content, branch=self.branch, sha=fileSha, message=message, force='true' )
+    if self._dryRun:
+      coDict.pop('content')
+      self.log.info( "DryRun: not actually making commit: %s", coDict )
+      return
+
+    result = curl2Json( ghHeaders(), '-X','PUT',
+                        '-d %s ' % json.dumps( coDict ),
+                        self._github( "contents/%s" % filename ) )
+
+    if 'commit' not in result:
+      raise RuntimeError( "Failed to update file: %s" % result['message'] )
+
+    return result
+
+
+  def createGithubPR( self, sourceBranch, targetRepo, targetBranch ):
+    """ create a PR on Github
+
+
+    :param str sourceBranch: branch the PR is based on
+    :param str targetRepo: target repository for the PR
+    :param str targetBranch: target for the PR
+    """
+
+    title = "Mirror from gitlab MR: %s" % sourceBranch
+    prDict = dict( branch=sourceBranch, base=targetBranch, title=title, sourceRepo=self.repo, targetRepo=targetRepo )
+    if not all( opt in prDict for opt in ( 'branch', 'base', 'title', 'sourceRepo', "FIXME" ) ):
+      self.log.error( "Missing some option in the option dict: %s" , prDict )
+
+    result = curl2Json( ghHeaders(),
+                        '-d { "title": "%(title)s", "head": "%(branch)s", "base": "%(base)s"}' % prDict ,
+                        self._github( "pulls" ) )
+
+    if 'errors' in result:
+      for error in result['errors']:
+        self.log.error( "ERROR creating PullRequest: %s", error['message'] )
+      return False
+    else:
+      self.log.info( "Created pullrequest" )
+      url = result['html_url']
+      return url
+
+
+  def isUpToDate( self ):
+    """ return True/False wether we have to make a new tag or not"""
+    if self.latestTagInfo['sha'] != self._lastCommitOnBranch['sha']:
+      return False
+
+    ## this means the commits are the same, but maybe we want to make a proper tag now
+    if 'pre' in self.latestTagInfo['name'] and 'pre' not in self.newTag:
+      return False
+
+    return True

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -1,0 +1,143 @@
+""" helper functions for the gitinterface """
+
+import json
+import logging
+import subprocess
+import re
+try:
+  from GitTokens import GITHUBTOKEN
+except ImportError:
+  raise ImportError("""Failed to import GITHUBTOKEN please point the pythonpath to your GitTokens.py file which contains four "Personal Access Token" for Github
+
+                    I.e.:
+                    Filename: GitTokens.py
+                    Content:
+                    ```
+                    GITHUBTOKEN = "e0b83063396fc632646603f113437de9"
+                    ```
+                    (without the triple quotes)
+                    """
+                   )
+
+
+def versionComp( v1, v2 ):
+  """ compare version strings, problem is comparing
+  v1r8p0 to v02-07-00 e.g. in lcio otherwise we could use normal string comparison
+
+  needed for LCIO
+  """
+  if v1 == v2:
+    return 0
+
+  pattern = re.compile( 'v([0-9]+)[r]([0-9]+)[-p]([0-9]+)')
+
+  result1 = re.match( pattern, v1 )
+
+  result2 = re.match( pattern, v2 )
+
+  ## matching result1
+  if result1 is not None and result2 is not None:
+    ## both match, we can use string comparison
+    pass
+  elif result1 is not None and result2 is None:
+    ## only 1 matches, 2 is always assumed to be bigger
+    return -1
+  elif result1 is None and result2 is not None:
+    ## only 2 matches, 1 is considered bigger
+    return 1
+  else:
+    ## neither matches, we can use string comparison
+    pass
+  
+  if v1 < v2:
+    return -1
+  else:
+    return 1
+  
+
+def parseForReleaseNotes( commentBody ):
+  """ will look for "BEGINRELEASENOTES / ENDRELEAENOTES" and extend releaseNoteList if there are entries """
+
+  relNotes = []
+  if not all( tag in commentBody for tag in ("BEGINRELEASENOTES", "ENDRELEASENOTES") ):
+    return relNotes
+
+  releaseNotes=commentBody.split("BEGINRELEASENOTES")[1].split("ENDRELEASENOTES")[0]
+  relNotes.append( releaseNotes )
+  # for entry in releaseNotes.split("*"):
+  #   if entry.strip():
+  #     relNotes.append( entry.strip() )
+
+  return relNotes
+
+def ghHeaders( ):
+  """ return authorization header for github as used by curl
+
+  :returns: tuple to be used in commands list
+  """
+  return '-H','Authorization: token %s' % GITHUBTOKEN
+
+
+def getCommands( *args ):
+  """ create a flat list
+
+  :param *args: list of strings or tuples/lists
+  :returns: flattened list of strings
+  """
+  comList = []
+  for arg in args:
+    if isinstance( arg, (tuple, list) ):
+      comList.extend(arg)
+    else:
+      comList.append(arg)
+  return comList
+
+
+def curl2Json( *commands, **kwargs ):
+  """ return the json object from calling curl with the given commands
+
+  :param *commands: list of strings or tuples/lists, will be passed to `getCommands` to be flattend
+  :returns: json object returned from the github or gitlab API
+  """
+  log = logging.getLogger("GitHub")
+  commands = getCommands( *commands )
+  commands.insert( 0, 'curl' )
+  commands.insert( 1, '-s' )
+  if kwargs.get("checkStatusOnly", False):
+    commands.insert( 1, '-I' )
+  log.debug( "Running command: %r", commands )
+  jsonText = subprocess.check_output( commands )
+  try:
+    jsonList = json.loads( jsonText )
+  except ValueError:
+    if kwargs.get("checkStatusOnly", False):
+      return jsonText
+    raise
+  return jsonList
+
+
+
+AUTHORMAP = {}
+def authorMapping( username, commands ):
+  """return the name of the author for given username, if not found query github
+  PR for author via the commands given
+  """
+  log = logging.getLogger("Author")
+  author = AUTHORMAP.get(username)
+  if author is not None:
+    log.debug( "Found author in map: %s", author)
+    return author
+
+  log.debug( "Checking Commits for Author ")
+  commits = curl2Json( commands )
+  author = commits[-1]['commit']['author']['name'] ## use the last commit of PR to get author
+  AUTHORMAP[username] = author
+  log.debug( "Found author: %s", author )
+  return author
+
+
+def checkRate():
+  """ return the result for check_rate call """
+  rate = curl2Json( ghHeaders(), "https://api.github.com/rate_limit" )
+  logging.getLogger("Rate").info("Remaining calls to github API are %s of %s", rate['rate']['remaining'], rate['rate']['limit'] )
+

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -1,0 +1,122 @@
+"""
+module to parse version strings in ilcsoft
+"""
+
+from logging import getLogger
+
+class Version( object ):
+  """
+  e.g.
+
+  v01-00
+  v01-00-pre
+  v01-00-pre1
+  v01-01-01-pre8
+
+  """
+
+  def __init__( self, versionString, makePreRelease=True ):
+    self.version = versionString
+    self.major = 0
+    self.minor = 0
+    self.patch = None
+    self.pre = None
+    self.isPre = False
+    self.makePreRelease=makePreRelease
+    self.log = getLogger( "Version" )
+
+    try:
+      self._parseVersion()
+    except ValueError as err:
+      self.log.error("Failed to parse version: %s", str(err) )
+      raise RuntimeError( "broken version string" )
+
+  def _parseVersion( self ):
+    """ parse the version string """
+    ## strip starting parts, e.g. CondBMYSQL_ILC-
+    self.version = self.version.lstrip('vABCDEFGHIJKLMNOPQRSTUVWXZYabcdefghijklmnopqrstuvwxzy_-')
+    parts = self.version.lstrip('v').split("-")
+    if 'pre' in self.version:
+      self.isPre = True
+
+    if len(parts) >= 2:
+      self.major = int(parts[0])
+      self.minor = int(parts[1])
+    else:
+      raise RuntimeError( "Cannot parse this version string: %s" % self.version )
+
+    if len(parts) >= 3:
+      if 'pre' == parts[2]:
+        self.pre = 0
+      elif 'pre' in parts[2]:
+        self.pre = int(parts[2].strip('pre'))
+      else:
+        self.patch = int( parts[2] )
+
+    if len(parts) >= 4:
+      if 'pre' == parts[3]:
+        self.pre = 0
+      elif 'pre' in parts[3]:
+        self.pre = int(parts[3].strip('pre'))
+      else:
+        raise RuntimeError( "Cannot parse this version string: %s" % self.version )
+
+
+  def __incrementPatch( self ):
+    """ return version with patch version incremented """
+    if self.patch is None:
+      self.patch = 1
+    else:
+      self.patch += 1
+    return str(self)
+
+  def __incrementPreRelease( self ):
+    """ return version with prerelease version incremented """
+    if self.pre is None:
+      self.pre = 0
+    else:
+      self.pre += 1
+    return str(self)
+
+  def increment( self ):
+    """ return the version string incremented by patch or pre-release
+    if version was pre-release we increment the pre-release if we want to have a pre-release
+    if the version was a pre-release, but we do not want a pre-release we drop the pre, but keep the patch.
+    if the version was no pre-release, but we want a pre-release we make it a pre-release and increase the patch
+    if the version was no pre-release, but and we want a proper release, increase the patch
+    """
+    if self.isPre and self.makePreRelease:
+      self.__incrementPreRelease()
+      self.log.info( "Making new PreRelease: %s", self )
+      return
+    elif self.isPre and not self.makePreRelease:
+      self.isPre = False
+      self.log.info( "Making new Release: %s", self )
+      return
+    elif not self.isPre and self.makePreRelease:
+      self.isPre = True
+      self.__incrementPatch()
+      self.__incrementPreRelease()
+      self.log.info( "Making new PreRelease: %s", self )
+      return
+    else: ## no prelrease, proper release
+      self.__incrementPatch()
+      self.log.debug( "Making new Release: %s", self )
+      return
+
+  def __str__( self ):
+    """ return version string """
+    versionString = "v%02d-%02d" % ( self.major, self.minor )
+    if self.patch is not None:
+      versionString += "-%02d" % self.patch
+
+    if self.makePreRelease:
+      versionString += "-pre"
+      if self.pre > 0:
+        versionString += "%d" % self.pre
+
+    return versionString
+
+  def getMajorMinorPatch( self ):
+    """ :returns: tuple of Major, Minor Patch """
+    return self.major, self.minor, self.patch


### PR DESCRIPTION
needs python 2.7
runs from the scripts folder (unless you export path and pythonpath to point to the right places)

GitTokens.py needs to be in a folder in the PYTHONPATH

usage:

    ilcsofttagger --packages lcgeo marlin aidasoft/dd4hep fcalsw/fcalclusterer ... [--properRelease] [--makeTags] [--file packageFile]

    * default is dry run mode use --makeTags to actually make the releases

    * default is pre-release tags, use --properRelease to make real release

    * The script will parse github pull requests to collate release notes
      and write them into doc/ReleaseNotes.md

    * The script will update the _VERSION_MAJOR, MINOR, PATH in the base
      CMakeLists.txt file to the new version

    * One needs a github personal access token in a file called
      GitTokens.py in a constant called GITHUBTOKEN, see helperfunctions
      for details, also the ImportError will give this information

    * Will not make another prerelease tag if there are no new commits
      since the last tag Release notes are always written for the new
      version

    * to set the version number give the repo onwer (ilcsoft) and the
      version number afterwards ilcsofttagger --packages
      ilcsoft/lcgeo/v10-00 ... [--properRelease] [--makeTags]

    * can also use a configuration file which contains the same kind of
      strings

        ilcsofttagger --file configFile

    * see ilcsofttagger --help as well


Example release notes for lcgeo
                                                                                           
# v00-10-01                                                                             

* 2017-03-24 Emilia Leogrande ([PR#60](https://github.com/iLCSoft/lcgeo/pull/60))
  - Replace ILDCellID0 with LCTrackerCellID

* 2017-03-27 Daniel Jeans ([PR#61](https://github.com/iLCSoft/lcgeo/pull/61))
  - Fix bugs in barrel modules size introduced when generalising barrel symmetry
  - Exit gracefully if too many sides requested for barrel

* 2017-03-29 Frank Gaede ([PR#63](https://github.com/iLCSoft/lcgeo/pull/63))
  - add info printout if sensitive action is changed from the default

* 2017-03-30 Frank Gaede ([PR#67](https://github.com/iLCSoft/lcgeo/pull/67))
  - fix a bug in the field maps  FieldMapBrBz.cpp  and FieldMapXYZ.cpp  that prevented overlay
  - (fixes https://github.com/iLCSoft/lcgeo/issues/65 )




BEGINRELEASENOTES
- add ilcsofttagger

ENDRELEASENOTES