### PR TITLE
Fix tag

### DIFF
--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -422,7 +422,7 @@ class Repo(object):
     major, minor, patch = self._version.getMajorMinorPatch()
     pMajor = re.compile('_VERSION_MAJOR [0-9]*')
     pMinor = re.compile('_VERSION_MINOR [0-9]*')
-    pPatch = re.compile('_VERSION_PATCH [0-9]*')
+    pPatch = re.compile('_VERSION_PATCH [0-9a-zA-Z]*')
     content = pMajor.sub( "_VERSION_MAJOR %s" % major, content )
     content = pMinor.sub( "_VERSION_MINOR %s" % minor, content )
     content = pPatch.sub( "_VERSION_PATCH %s" % patch, content )

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -118,5 +118,6 @@ class Version( object ):
     return versionString
 
   def getMajorMinorPatch( self ):
-    """ :returns: tuple of Major, Minor Patch """
-    return self.major, self.minor, self.patch
+    """ :returns: tuple of Major, Minor, Patch """
+    patch = 0 if self.patch is None else self.patch
+    return self.major, self.minor, patch


### PR DESCRIPTION
The clupatra patch number was set to "None"
this fixes that problem.

Note: 
 * The removed author line was not a bug. The first line of the ReleaseNotes.md is intentionally removed because it is assumed to be the version string that gets replaced if the last release was a pre-release version. Something that will not be a problem in the future.
* No release notes because only a bug fix to something in the same release.