### PR TITLE
Added '-DGBL_EIGEN_SUPPORT_ROOT' to 'CMAKE_CXX_FLAGS' for aidaTT.

### DIFF
--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -194,6 +194,7 @@ ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_CXX11"] = 'ON'
 ilcsoft.install( lcgeo( lcgeo_version ))
 
 ilcsoft.install( aidaTT( aidaTT_version ))
+ilcsoft.module("aidaTT").envcmake["CMAKE_CXX_FLAGS"]="-DGBL_EIGEN_SUPPORT_ROOT"
 
 ilcsoft.install( DDKalTest( DDKalTest_version ))
 

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -244,6 +244,7 @@ ilcsoft.install( aidaTT( aidaTT_version ))
 ilcsoft.module("aidaTT").download.type="GitHub"
 ilcsoft.module("aidaTT").download.gituser="AIDASoft"
 ilcsoft.module("aidaTT").download.gitrepo="aidaTT"
+ilcsoft.module("aidaTT").envcmake["CMAKE_CXX_FLAGS"]="-DGBL_EIGEN_SUPPORT_ROOT"
 
 ilcsoft.install( DDKalTest( DDKalTest_version ))
 

--- a/releases/v01-19/release-ilcsoft.cfg
+++ b/releases/v01-19/release-ilcsoft.cfg
@@ -247,6 +247,7 @@ ilcsoft.install( aidaTT( aidaTT_version ))
 ilcsoft.module("aidaTT").download.type="GitHub"
 ilcsoft.module("aidaTT").download.gituser="AIDASoft"
 ilcsoft.module("aidaTT").download.gitrepo="aidaTT"
+ilcsoft.module("aidaTT").envcmake["CMAKE_CXX_FLAGS"]="-DGBL_EIGEN_SUPPORT_ROOT"
 
 ilcsoft.install( DDKalTest( DDKalTest_version ))
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Follow the GBL update, to add option "GBL_EIGEN_SUPPORT_ROOT" in aidaTT.
  - GBLInterface.cc still using ROOT for this moment.

ENDRELEASENOTES