### PR TITLE
Tagging: Fill last tag info in Repo constructor, fixes #18

### DIFF
--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -38,6 +38,7 @@ class Repo(object):
     self._newVersion = None
     self.newVersion = newVersion
     self._version = None
+    self._getLatestTagInfo()
     self._setNewVersion()
     self._dryRun = dryRun
 


### PR DESCRIPTION
ensure latestTagInfo is filled before, e.g., isUpToDate is called
