### PR TITLE
Tagging: use correct (pre)-tag name when making release, fixes #21

### DIFF
--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -243,7 +243,7 @@ class Repo(object):
       return
 
 
-    releaseDict = dict( tag_name=self.newVersion,
+    releaseDict = dict( tag_name=self.newTag,
                         target_commitish=self.branch,
                         name=self.newTag,
                         body=self.formatReleaseNotes(),


### PR DESCRIPTION
Give the tag the same name as the release