### PR TITLE
Tagging Improvements, Tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+omit =
+     */Tests/*
+
+[report]
+omit =
+     *Test_*.py
+     *test_*.py
+     *tests/*
+     *Tests/*

--- a/.travis-ci.d/requirements.txt
+++ b/.travis-ci.d/requirements.txt
@@ -1,10 +1,5 @@
-funcsigs
-pexpect>=4.0.1
 Pygments>=1.5
 pyparsing>=2.0.6
-pytz>=2015.7
-readline>=6.2.4
-requests>=2.9.1
 simplejson>=3.8.1
 six
 mock>=2

--- a/.travis-ci.d/requirements.txt
+++ b/.travis-ci.d/requirements.txt
@@ -1,0 +1,16 @@
+funcsigs
+pexpect>=4.0.1
+Pygments>=1.5
+pyparsing>=2.0.6
+pytz>=2015.7
+readline>=6.2.4
+requests>=2.9.1
+simplejson>=3.8.1
+six
+mock>=2
+pylint>=1.4.4
+pytest>=2.8.5
+pytest-cov>=2.2.0
+coverage>=4.0.3
+python-coveralls
+ipython==5.3.0

--- a/.travis-ci.d/run-unittests.sh
+++ b/.travis-ci.d/run-unittests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source .travis-ci.d/set-reportstyle.sh
+export PYTEST_ADDOPTS=$PYTEST_ADDOPTS" -m 'not integration'"
+py.test

--- a/.travis-ci.d/set-reportstyle.sh
+++ b/.travis-ci.d/set-reportstyle.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docker="/root/"
+echo "Checking which report style to use ................................................................"
+if [ "$HOME" == "$docker" ]
+then
+  # use default report style, but reset PYTEST_ADDOPTS in case of multiple runs
+  export PYTEST_ADDOPTS=""
+else
+  # use nice html file output in default directory (htmlcov)
+  export PYTEST_ADDOPTS="--cov-report html"
+  echo "Switched to HTML Report style"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+cache: pip
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r .travis-ci.d/requirements.txt"
+# command to run tests
+script:
+  - export PYTHONPATH=${PWD%/*}
+  - echo $PYTHONPATH
+  - .travis-ci.d/run-unittests.sh
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ iLCInstall is distributed under the [GPLv3 License](http://www.gnu.org/licenses/
 
 [![License](https://www.gnu.org/graphics/gplv3-127x51.png)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
+[![Build Status](https://travis-ci.org/ilcsoft/iLCInstall.svg?branch=master)](https://travis-ci.org/ilcsoft/iLCInstall)
+[![Coverage Status](https://coveralls.io/repos/github/iLCSoft/iLCInstall/badge.svg?branch=master)](https://coveralls.io/github/iLCSoft/iLCInstall?branch=master)
+
 ## Usage
 
 The script can be called with the following syntax:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts= -v --cov .
+python_files=[tT]est*.py # find all Test*, Test_*, *tests, *test, etc. files. Might have a few false positives
+python_classes=*
+python_functions=test_*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 addopts= -v --cov .
 python_files=[tT]est*.py # find all Test*, Test_*, *tests, *test, etc. files. Might have a few false positives
-python_classes=*
+python_classes=Test*
 python_functions=test_*

--- a/scripts/ilcsofttagger.py
+++ b/scripts/ilcsofttagger.py
@@ -195,10 +195,10 @@ class ILCSoftTagger(object):
       try:
         dryRun = not self.makeTags
         thisPackage = Repo( owner, package, branch=branch, newVersion=version, preRelease=prerelease, dryRun=dryRun)
+        self.repos.append( thisPackage )
       except RuntimeError as e:
-        self.log.error( "Failure for %s", thisPackage )
+        self.log.error( "Failure for %s/%s/%s/%s", owner, package, branch, version )
         self.errors.append( str(e) )
-      self.repos.append( thisPackage )
 
     if self.errors:
       self.abort()

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -94,7 +94,7 @@ class Repo(object):
       raise RuntimeError( "Invalid version required" )
 
   def _getLatestTagInfo( self ):
-    """ fill the information about the latest tag in the repository, ignore pre commit tags"""
+    """ fill the information about the latest tag in the repository"""
     if self.latestTagInfo is not None:
       self.log.debug( "Latest Tag Info already filled" )
       return self.latestTagInfo ## already filled

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -88,7 +88,9 @@ class Repo(object):
   def _checkConsistency( self ):
     """ check for invalid version requirements"""
     lastTag = self.latestTagInfo['name']
-    if self._nextRealRelease == lastTag or versionComp( self._nextRealRelease, lastTag ) <= 0:
+    if self._nextRealRelease == lastTag \
+       or versionComp( self._nextRealRelease, lastTag ) <= 0 \
+       or versionComp( self.newTag, lastTag ) <= 0:
       self.log.error("Required (pre-)version (%r) is the same as or older than the last tag(%r)",
                      self.newVersion, lastTag)
       raise RuntimeError( "Invalid version required" )

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -41,6 +41,7 @@ class Repo(object):
     self._getLatestTagInfo()
     self._setNewVersion()
     self._dryRun = dryRun
+    self._checkConsistency()
 
   def __str__( self ):
     return self.owner+"/"+self.repo
@@ -83,6 +84,14 @@ class Repo(object):
     self._newTag.increment()
     self._nextRealRelease = str( self._newTag ).split("-pre")[0]
     self.log.info( "Set new version: %s", self._nextRealRelease )
+
+  def _checkConsistency( self ):
+    """ check for invalid version requirements"""
+    lastTag = self.latestTagInfo['name']
+    if self._nextRealRelease == lastTag or versionComp( self._nextRealRelease, lastTag ) <= 0:
+      self.log.error("Required (pre-)version (%r) is the same as or older than the last tag(%r)",
+                     self.newVersion, lastTag)
+      raise RuntimeError( "Invalid version required" )
 
   def _getLatestTagInfo( self ):
     """ fill the information about the latest tag in the repository, ignore pre commit tags"""

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -122,7 +122,11 @@ def curl2Json( *commands, **kwargs ):
   commands.insert( 1, '-s' )
   if kwargs.get("checkStatusOnly", False):
     commands.insert( 1, '-I' )
-  log.debug( "Running command: %r", commands )
+  cleanedCommands = list(commands)
+  ## replace the github token with Xs
+  if '-H' in cleanedCommands:
+    cleanedCommands[commands.index('-H')+1] = cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[0] + " "+ "X"*len(cleanedCommands[commands.index('-H')+1].rsplit(" ", 1)[1])
+  log.debug( "Running command: %r",  cleanedCommands )
   jsonText = subprocess.check_output( commands )
   try:
     jsonList = json.loads( jsonText )

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -87,7 +87,7 @@ def getCommands( *args ):
   comList = []
   for arg in args:
     if isinstance( arg, (tuple, list) ):
-      comList.extend(arg)
+      comList.extend( getCommands( *arg ) )
     else:
       comList.append(arg)
   return comList

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -7,7 +7,7 @@ import re
 try:
   from GitTokens import GITHUBTOKEN
 except ImportError:
-  raise ImportError("""Failed to import GITHUBTOKEN please point the pythonpath to your GitTokens.py file which contains four "Personal Access Token" for Github
+  raise ImportError("""Failed to import GITHUBTOKEN please point the pythonpath to your GitTokens.py file which contains your "Personal Access Token" for Github
 
                     I.e.:
                     Filename: GitTokens.py

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -25,6 +25,9 @@ def versionComp( v1, v2 ):
   v1r8p0 to v02-07-00 e.g. in lcio otherwise we could use normal string comparison
 
   needed for LCIO
+
+  pre version are older than non-pre version
+
   """
   if v1 == v2:
     return 0
@@ -48,6 +51,20 @@ def versionComp( v1, v2 ):
   else:
     ## neither matches, we can use string comparison
     pass
+
+  if 'pre' in v1 and 'pre' in v2:
+    ## use string comparison later
+    pass
+
+  elif 'pre' in v1:
+    if v1.split('-pre')[0]==v2:
+      return -1 # version 2 is not pre, so bigger
+    return -1 if v1.split('-pre')[0] < v2 else 1
+
+  elif 'pre' in v2:
+    if v1==v2.split('-pre')[0]:
+      return 1 # version 1 is not pre, so bigger
+    return -1 if v1 <= v2.split('-pre')[0] else 1
   
   if v1 < v2:
     return -1

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -34,7 +34,7 @@ def mockCurl(*args, **kwargs):
   logging.error("\nArgs: %r", args)
   logging.error("\nArgs: %r", getCommands(args))
   logging.error("Kwargs: %r", kwargs )
-  
+
   cmdString = " ".join( getCommands(args) )
   logging.error( "ComdString: %s", cmdString )
   if "/tags" in cmdString:
@@ -71,11 +71,11 @@ def mockCurl(*args, **kwargs):
              "author": { "date": "2014-11-07T22:01:45Z",
                          "name": "Scott Chacon",
                          "email": "schacon@gmail.com"
-             },
+                       },
              "committer": { "date": "2014-11-07T22:01:45Z",
                             "name": "Scott Chacon",
                             "email": "schacon@gmail.com"
-             },
+                          },
              "message": "added readme, because im a good github citizen",
              "tree": { "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
                        "sha": "myCommitSha"
@@ -129,7 +129,7 @@ def mockCurl(*args, **kwargs):
                        },
              "protected": True,
              "protection_url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection"
-           } 
+           }
 
   ##default
   return {}
@@ -366,21 +366,21 @@ class TestParseVersion( unittest.TestCase ):
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 0) )
 
     version = Version( "v01-02-13", makePreRelease=False )
-    self.assertEqual( str(version), "v01-02-13" ) 
+    self.assertEqual( str(version), "v01-02-13" )
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 13) )
 
 
-  
+
     version = Version( "v01-02-14-pre13" )
     self.assertEqual( str(version), "v01-02-14-pre13" )
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 14) )
 
     version = Version( "v01-02-13-pre16", makePreRelease=False )
-    self.assertEqual( str(version), "v01-02-13" ) 
+    self.assertEqual( str(version), "v01-02-13" )
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 13) )
-  
-  
-    
+
+
+
   def test_getMajorMinorPatch( self ):
     """ test from pre to increment pre"""
     version = Version( "v01-02", makePreRelease=True )
@@ -388,15 +388,16 @@ class TestParseVersion( unittest.TestCase ):
     self.assertFalse( version.isPre )
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 0) )
 
-    
-    
-    
-    
+
+
+
+
 def runTests():
   """Runs our tests"""
-  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestGit )
+  suite = unittest.TestSuite()
+  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestGit ) )
   suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestHelpers ) )
-  
+
   testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
   print testResult
 

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -186,8 +186,50 @@ class TestGit( unittest.TestCase ):
     self.assertFalse( self.repo.isPreRelease )
     self.assertTrue( self.repo._dryRun )
 
-    
-    
+
+  def test_ctor_fail_1( self ):
+    """ test the constructor when the desired pre-version is the same as an existing one"""
+    myTagInfo=[ { "name": "v01-03-20",
+                  "commit": { "sha": "MyTagSha2",
+                              "url": "http://localhost/foo/bar"
+                            },
+                  "zipball_url": "zipball/v0.1",
+                  "tarball_url": "tarball/v0.1"
+                }
+              ]
+
+    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+         patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
+      self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20-pre", preRelease=True, dryRun=True)
+
+  def test_ctor_fail_2( self ):
+    """ test the constructor when the desired pre-version is the same as an existing one"""
+    myTagInfo=[ { "name": "v01-03-20",
+                  "commit": { "sha": "MyTagSha2",
+                              "url": "http://localhost/foo/bar"
+                            },
+                  "zipball_url": "zipball/v0.1",
+                  "tarball_url": "tarball/v0.1"
+                }
+              ]
+
+  def test_ctor_fail_2( self ):
+    """ test the constructor when the desired pre-version is the same as an existing one"""
+    myTagInfo=[ { "name": "v01-03-20-pre2",
+                  "commit": { "sha": "MyTagSha2",
+                              "url": "http://localhost/foo/bar"
+                            },
+                  "zipball_url": "zipball/v0.1",
+                  "tarball_url": "tarball/v0.1"
+                }
+              ]
+
+
+    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+         patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
+      self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20-pre1", preRelease=True, dryRun=True)
+
+
 class TestHelpers( unittest.TestCase ):
   """ tests for the helper functions """
 

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -1,23 +1,33 @@
 #!/bin/env python
 """Test the Tagging Modules"""
 
+import json
 import logging
 import __builtin__
 import unittest
 import os
 import shutil
+import sys
 import tempfile
 import tarfile
 from zipfile import ZipFile
 from mock import patch, MagicMock as Mock, mock_open
 from pprint import pprint
 
+sys.modules['GitTokens'] = Mock(name="GitTokensMock", return_value=Mock(name="returnedMock"))
+
 from tagging.gitinterface import Repo
-from tagging.helperfunctions import getCommands, versionComp
+from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, curl2Json
 from tagging.parseversion import Version
 
 __RCSID__ = "$Id$"
 
+REALIMPORT = __builtin__.__import__
+def myimport(name, globs, locs, fromlist):
+  """ raise error for import """
+  if name=="GitTokens" and "GITHUBTOKEN" in fromlist:
+    raise ImportError
+  return REALIMPORT(name, globs, locs, fromlist)
 
 def mockCurl(*args, **kwargs):
   """ mock the curl2Json calls in the gitinterface """

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -1,0 +1,306 @@
+#!/bin/env python
+"""Test the Tagging Modules"""
+
+import logging
+import __builtin__
+import unittest
+import os
+import shutil
+import tempfile
+import tarfile
+from zipfile import ZipFile
+from mock import patch, MagicMock as Mock, mock_open
+from pprint import pprint
+
+from tagging.gitinterface import Repo
+from tagging.helperfunctions import getCommands, versionComp
+from tagging.parseversion import Version
+
+__RCSID__ = "$Id$"
+
+
+def mockCurl(*args, **kwargs):
+  """ mock the curl2Json calls in the gitinterface """
+  logging.error("\nArgs: %r", args)
+  logging.error("\nArgs: %r", getCommands(args))
+  logging.error("Kwargs: %r", kwargs )
+  
+  cmdString = " ".join( getCommands(args) )
+  logging.error( "ComdString: %s", cmdString )
+  if "/tags" in cmdString:
+    logging.error("Returning tags structure")
+    return [ { "name": "v01-03-19",
+               "commit": { "sha": "MyTagSha2",
+                           "url": "http://localhost/foo/bar"
+                         },
+               "zipball_url": "zipball/v0.1",
+               "tarball_url": "tarball/v0.1"
+             }
+           ]
+
+  if "/tag" in cmdString:
+    logging.error( "Returning single tag" )
+    return { "tag": "v1-03-19",
+             "sha": "MyTagSha01",
+             "url": "http://localhost/foo/bar/baz",
+             "message": "initial version",
+             "tagger": { "name": "Foo Bar",
+                         "email": "foo@bar.org",
+                         "date": "2014-11-07T22:01:45Z"
+                       },
+             "object": { "type": "commit",
+                         "sha": "myCommitSha1",
+                         "url": "https://foo.org/git/commits/myCommitSha1"
+                       }
+           }
+  if "/git/commits/" in cmdString:
+    logging.error( "Returning single commit" )
+
+    return { "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
+             "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",
+             "author": { "date": "2014-11-07T22:01:45Z",
+                         "name": "Scott Chacon",
+                         "email": "schacon@gmail.com"
+             },
+             "committer": { "date": "2014-11-07T22:01:45Z",
+                            "name": "Scott Chacon",
+                            "email": "schacon@gmail.com"
+             },
+             "message": "added readme, because im a good github citizen",
+             "tree": { "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/691272480426f78a0138979dd3ce63b77f706feb",
+                       "sha": "myCommitSha"
+                     },
+             "parents": [ { "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5",
+                            "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5"
+                          }
+                        ]
+           }
+
+  if "/branches" in cmdString:
+    return { "name": "master",
+             "commit": { "sha": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+                         "commit": { "author": { "name": "The Octocat",
+                                                 "date": "2012-03-06T15:06:50-08:00",
+                                                 "email": "octocat@nowhere.com"
+                                               },
+                                     "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+                                     "message": "Merge pull request #6 from Spaceghost/patch-1\n\nNew line at end of file.",
+                                     "tree": { "sha": "b4eecafa9be2f2006ce1b709d6857b07069b4608",
+                                               "url": "https://api.github.com/repos/octocat/Hello-World/git/trees/b4eecafa9be2f2006ce1b709d6857b07069b4608"
+                                             },
+                                     "committer": { "name": "The Octocat",
+                                                    "date": "2012-03-06T15:06:50-08:00",
+                                                    "email": "octocat@nowhere.com"
+                                                  }
+                                   },
+                         "author": { "gravatar_id": "",
+                                     "avatar_url": "https://secure.gravatar.com/avatar/7ad39074b0584bc555d0417ae3e7d974?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png",
+                                     "url": "https://api.github.com/users/octocat",
+                                     "id": 583231,
+                                     "login": "octocat"
+                                   },
+                         "parents": [ { "sha": "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
+                                        "url": "https://api.github.com/repos/octocat/Hello-World/commits/553c2077f0edc3d5dc5d17262f6aa498e69d6f8e"
+                                      },
+                                      { "sha": "762941318ee16e59dabbacb1b4049eec22f0d303",
+                                        "url": "https://api.github.com/repos/octocat/Hello-World/commits/762941318ee16e59dabbacb1b4049eec22f0d303"
+                                      }
+                                    ],
+                         "url": "https://api.github.com/repos/octocat/Hello-World/commits/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+                         "committer": { "gravatar_id": "",
+                                        "avatar_url": "https://secure.gravatar.com/avatar/7ad39074b0584bc555d0417ae3e7d974?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png",
+                                        "url": "https://api.github.com/users/octocat",
+                                        "id": 583231,
+                                        "login": "octocat"
+                                      }
+                       },
+             "_links": { "html": "https://github.com/octocat/Hello-World/tree/master",
+                         "self": "https://api.github.com/repos/octocat/Hello-World/branches/master"
+                       },
+             "protected": True,
+             "protection_url": "https://api.github.com/repos/octocat/Hello-World/branches/master/protection"
+           } 
+
+  ##default
+  return {}
+
+
+#pylint: disable=too-many-public-methods, protected-access
+
+
+def cleanup(tempdir):
+  """
+  Remove files after run
+  """
+  try:
+    shutil.rmtree(tempdir)
+  except OSError:
+    pass
+
+@patch("tagging.gitinterface.curl2Json",new=mockCurl)
+class TestGit( unittest.TestCase ):
+  """ test Gitinterface function """
+
+  def assertIn(self, *args, **kwargs):
+    """make this existing to placate pylint"""
+    return super(TestGit, self).assertIn(*args, **kwargs)
+
+  def setUp( self ):
+    self.repo = None
+
+  def tearDown( self ):
+    pass
+
+
+  def test_ctor_pre_1( self ):
+    """ test the constructor """
+    self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion=None, preRelease=True, dryRun=True)
+    self.assertEqual( self.repo.newVersion, "v01-03-20" )
+    self.assertEqual( self.repo.newTag, "v01-03-20-pre" )
+    self.assertTrue( self.repo.isPreRelease )
+    self.assertTrue( self.repo._dryRun )
+
+  def test_ctor_pre_2( self ):
+    """ test the constructor """
+    self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20", preRelease=True, dryRun=True)
+    self.assertEqual( self.repo.newVersion, "v01-03-20" )
+    self.assertEqual( self.repo.newTag, "v01-03-20-pre" )
+    self.assertTrue( self.repo.isPreRelease )
+    self.assertTrue( self.repo._dryRun )
+
+  def test_ctor_2( self ):
+    """ test the constructor """
+    self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20", preRelease=False, dryRun=True)
+    self.assertEqual( self.repo.newVersion, "v01-03-20" )
+    self.assertEqual( self.repo.newTag, "v01-03-20" )
+    self.assertFalse( self.repo.isPreRelease )
+    self.assertTrue( self.repo._dryRun )
+
+    
+    
+class TestHelpers( unittest.TestCase ):
+  """ tests for the helper functions """
+
+  def test_getCommands_tuple( self ):
+    t1 = [(1, 2), 3 ]
+    self.assertEqual( getCommands(*t1), [1, 2, 3] )
+  def test_getCommands_list( self ):
+    t1 = [ [[1, 2], 3], 4, 5, [6, 7] ]
+    self.assertEqual( getCommands(*t1), [1, 2, 3, 4, 5, 6, 7] )
+
+
+  def testVersionComp( self ):
+    """ test version comparison """
+
+    self.assertEqual( versionComp( "foo", "foo" ), 0 )
+    self.assertLess( versionComp( "v01-12", "v2-11" ), 0 )
+
+    self.assertLess( versionComp( "v1r12p12", "v2-11" ), 0 )
+    self.assertLess( versionComp( "v1r12p12", "v1r13p12" ), 0 )
+
+    self.assertGreater( versionComp( "v1r13p12", "v1r12p12" ), 0 )
+    self.assertGreater( versionComp( "v1-13-12", "v1r12p12" ), 0 )
+ 
+
+class TestParseVersion( unittest.TestCase ):
+  """ tests for the helper functions """
+
+  def test_v1( self ):
+    """ test from pre to pre """
+    version = Version( "v00-00", makePreRelease=True )
+    self.assertEqual( str(version), "v00-00-pre" )
+    version.increment()
+    self.assertEqual( str(version), "v00-00-01-pre" )
+
+
+  def test_v2( self ):
+    """ test 2"""
+    version = Version( "v00-00", makePreRelease=False )
+    self.assertEqual( str(version), "v00-00" )
+    self.assertFalse( version.isPre )
+    version.increment()
+    self.assertEqual( str(version), "v00-00-01" )
+
+
+  def test_pre_increment( self ):
+    """ test from pre to increment pre"""
+    version = Version( "v01-02-03-pre", makePreRelease=True )
+    self.assertEqual( str(version), "v01-02-03-pre" )
+    self.assertTrue( version.isPre )
+    version.increment()
+    self.assertEqual( str(version), "v01-02-03-pre1" )
+
+
+  def test_v3( self ):
+    """ test from pre to release"""
+    version = Version( "v01-02-03-pre", makePreRelease=False )
+    self.assertEqual( str(version), "v01-02-03" )
+    self.assertTrue( version.isPre )
+    version.increment()
+    self.assertEqual( str(version), "v01-02-03" )
+
+
+  def test_v4( self ):
+    """ test from release to release"""
+    version = Version( "v01-02-04", makePreRelease=False )
+    self.assertEqual( str(version), "v01-02-04" )
+    self.assertFalse( version.isPre )
+    version.increment()
+    self.assertEqual( str(version), "v01-02-05" )
+
+  def test_parseVersions( self ):
+    """ test different version strings """
+
+    with self.assertRaises( RuntimeError ):
+      Version( "v01" )
+
+    with self.assertRaises( RuntimeError ):
+      Version( "v01-arg" )
+
+    with self.assertRaises( RuntimeError ):
+      Version( "v01-03-20-arg" )
+
+
+    self.assertEqual( str(Version( "v01-02-pre" )), "v01-02-pre" )
+
+    version = Version( "v01-02-pre13" )
+    self.assertEqual( str(version), "v01-02-pre13" )
+    self.assertEqual( version.getMajorMinorPatch(), (1, 2, 0) )
+
+    version = Version( "v01-02-13", makePreRelease=False )
+    self.assertEqual( str(version), "v01-02-13" ) 
+    self.assertEqual( version.getMajorMinorPatch(), (1, 2, 13) )
+
+
+  
+    version = Version( "v01-02-14-pre13" )
+    self.assertEqual( str(version), "v01-02-14-pre13" )
+    self.assertEqual( version.getMajorMinorPatch(), (1, 2, 14) )
+
+    version = Version( "v01-02-13-pre16", makePreRelease=False )
+    self.assertEqual( str(version), "v01-02-13" ) 
+    self.assertEqual( version.getMajorMinorPatch(), (1, 2, 13) )
+  
+  
+    
+  def test_getMajorMinorPatch( self ):
+    """ test from pre to increment pre"""
+    version = Version( "v01-02", makePreRelease=True )
+    self.assertEqual( str(version), "v01-02-pre" )
+    self.assertFalse( version.isPre )
+    self.assertEqual( version.getMajorMinorPatch(), (1, 2, 0) )
+
+    
+    
+    
+    
+def runTests():
+  """Runs our tests"""
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase( TestGit )
+  suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestHelpers ) )
+  
+  testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
+  print testResult
+
+if __name__ == '__main__':
+  runTests()

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -212,8 +212,11 @@ class TestGit( unittest.TestCase ):
                   "tarball_url": "tarball/v0.1"
                 }
               ]
+    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+         patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
+      self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-19", preRelease=True, dryRun=True)
 
-  def test_ctor_fail_2( self ):
+  def test_ctor_fail_3( self ):
     """ test the constructor when the desired pre-version is the same as an existing one"""
     myTagInfo=[ { "name": "v01-03-20-pre2",
                   "commit": { "sha": "MyTagSha2",
@@ -252,6 +255,16 @@ class TestHelpers( unittest.TestCase ):
 
     self.assertGreater( versionComp( "v1r13p12", "v1r12p12" ), 0 )
     self.assertGreater( versionComp( "v1-13-12", "v1r12p12" ), 0 )
+
+    self.assertLess( versionComp( "v1-13-12-pre", "v1-13-12" ), 0 )
+    self.assertGreater( versionComp( "v1-13-12", "v1-13-12-pre" ), 0 )
+
+    self.assertLess( versionComp( "v1-13-12-pre", "v1-14" ), 0 )
+    self.assertGreater( versionComp( "v1-14", "v1-13-12-pre" ), 0 )
+
+    self.assertGreater( versionComp( "v1-13-12-pre2", "v1-13-12-pre" ), 0 )
+    self.assertGreater( versionComp( "v1-13-13-pre2", "v1-13-12" ), 0 )
+    self.assertLess( versionComp( "v1-13-12", "v1-13-13-pre" ), 0 )
 
   def test_importError( self ):
     """ test the import error when not having githubtoken """


### PR DESCRIPTION
BEGINRELEASENOTES
- Added tests for large parts of the ilcsoft tagger files
- Prevent the printout of the githubtoken in DEBUG mode
- Prevent creation of tags that are older than the last tag (e.g., 2.8-pre if 2.8 was created already)
- Fix a bug in the error reporting of packages causing exception for using variable before it is assigned
- add --lastTag option to set the tag to use instead of finding the last tag automatically. Only works if a single package is specified

ENDRELEASENOTES