### PR TITLE
Force old default value for RELWITHDEBINFO

### DIFF
--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -343,12 +343,9 @@ class ILCSoft:
         f.write( "option(USE_CXX11" + " \"Use cxx11\" " + useCxx11 +")" )
         f.write( os.linesep )
         f.write( "option(Boost_NO_BOOST_CMAKE"  + " " + "\"dont use cmake find module for boost\"" + " " + noBoostCMake +")"  )
-        f2.write( "option(USE_CXX11" + " \"Use cxx11\" " + useCxx11 +")" )
-        f2.write( os.linesep )
-        f2.write( "option(Boost_NO_BOOST_CMAKE "  + " " + "\"dont use cmake find module for boost\"" + " " + noBoostCMake +")"  )
-
         f.write( os.linesep )
-        f2.write( os.linesep )
+        f.write( "set(CMAKE_CXX_FLAGS_RELWITHDEBINFO \"-O2 -g\" CACHE STRING \"\" FORCE )"  )
+        f.write( os.linesep )
 
         # close file
         f.close()


### PR DESCRIPTION
Since [this change](https://gitlab.kitware.com/cmake/cmake/commit/0ddfc51f6a68c61d84b5b4818b32ecbf755a949a) in CMake the default value for `RELWITHDEBINFO` has `DNDEBUG` added this suppresses all the debug output from streamlog when using default compilation. I think streamlog Debug output should only be suppressed in `Release`

BEGINRELEASENOTES
- Remove `-DNDEBUG` from the CMake default for `RELWITHDEBINFO`
- Remove cmake commands from the `ILCSoft.cmake.env.sh`

ENDRELEASENOTES