### PR TITLE
Use LCFIPlus from Github/LCFIPlus instead of lcfiplus/LCFIPlus in nightly

### DIFF
--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -103,9 +103,6 @@ ilcsoft.install( LCFIVertex( LCFIVertex_version ))
 ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path
 
 ilcsoft.install( MarlinPKG( "LCFIPlus", LCFIPlus_version ))
-ilcsoft.module("LCFIPlus").download.type="GitHub"
-ilcsoft.module("LCFIPlus").download.gituser="lcfiplus"
-ilcsoft.module("LCFIPlus").download.gitrepo="LCFIPlus"
 ilcsoft.module("LCFIPlus").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'Marlin', 'MarlinUtil', 'LCFIVertex'] )
 
 ilcsoft.install( CEDViewer( CEDViewer_version )) 


### PR DESCRIPTION

BEGINRELEASENOTES
- Use LCFIPlus from Github/LCFIPlus instead of lcfiplus/LCFIPlus in nightly

ENDRELEASENOTES