### PR TITLE
Upgrade ROOT_version to 6.08.06.

### DIFF
--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -121,7 +121,7 @@ Eigen_path = "/afs/desy.de/project/ilcsoft/sw/Eigen/3.2.9"
 Geant4_version =  "10.02.p02" 
 CLHEP_version =  "2.3.1.1"
 
-ROOT_version = "6.08.02"
+ROOT_version = "6.08.06"
 
 
 GSL_version = "2.1" 

--- a/releases/v01-19/release-versions.py
+++ b/releases/v01-19/release-versions.py
@@ -123,7 +123,7 @@ CLHEP_version =  "2.3.1.1"
 #Geant4_version =  "10.03" 
 #CLHEP_version =  "2.3.4.3"
 
-ROOT_version = "6.08.02"
+ROOT_version = "6.08.06"
 
 GSL_version = "2.1" 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Upgrade ROOT_version from 6.08.02 to 6.08.06
  - ROOT 6.08.02 has an unfortunate oversight in TBuffer.h
  - Both 6.08.00 and 6.08.06 are fine for DD4hep.

ENDRELEASENOTES