### PR TITLE
urllib to urllib2

### DIFF
--- a/ilcsoft/baseilc.py
+++ b/ilcsoft/baseilc.py
@@ -11,7 +11,7 @@
 from util import *
 
 import logging
-import urllib
+import urllib2 as urllib
 
 try:
     import simplejson as json

--- a/ilcsoft/cernlib.py
+++ b/ilcsoft/cernlib.py
@@ -44,7 +44,7 @@ class CERNLIB(BaseILC):
         trymakedir( self.installPath+'/sources' )
         os.chdir( os.path.dirname(self.installPath) )
 
-        import urllib
+        import urllib2 as urllib
 
         if self.version == '2005' :
             # cernlib fix from Harald Vogt: http://www-zeuthen.desy.de/~hvogt/


### PR DESCRIPTION

BEGINRELEASENOTES
- Changed urllib to urllib2 import to improve certificate check on url open

ENDRELEASENOTES