### PR TITLE
Use requests

### DIFF
--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -219,38 +219,6 @@ class Repo(object):
     treesha = result['tree']['sha']
     return treesha
 
-  # def createGithubTag( self ):
-  #   """
-  #   create a tag on the repository with `version` and on `branch`, makes tag on last commit of the branch
-  #   """
-  #   message = "New tag %s" % self.newVersion
-  #   prDict = dict( branch=self.branch, version=self.newVersion, message=message,
-  #                  gtype="commit"
-  #                )
-
-  #   prDict['sha'] = self.getHeadOfBranch()
-  #   if self._dryRun:
-  #     self.log.info( "DryRun: not actually making tag: %s", prDict )
-  #     return {}
-
-  #   result = curl2Json( ghHeaders(),
-  #                       '-d { "tag": "%(version)s", "message": "%(message)s", "object":"%(sha)s", "type":"%(gtype)s" '% prDict ,
-  #                       self._github( "git/tags" ) )
-  #   #pprint(result)
-
-  #   #FIXME: error message is actually different
-  #   if 'errors' in result:
-  #     for error in result['errors']:
-  #       self.log.error( "ERROR creating Tag: %s", error['message'] )
-  #     return False
-
-  #   prDict['tagSha'] = result['sha']
-
-  #   result = curl2Json( ghHeaders(),
-  #                       '-d { "ref": "refs/tags/%(version)s", "sha": "%(tagSha)s" '% prDict ,
-  #                       self._github( "git/refs" ) )
-  #   self.log.info( "New tag created" )
-  #   return result
 
   def createGithubRelease( self ):
     """ make a release on github """
@@ -467,32 +435,6 @@ class Repo(object):
       raise RuntimeError( "Failed to update file: %s" % result['message'] )
 
     return result
-
-
-  def createGithubPR( self, sourceBranch, targetRepo, targetBranch ):
-    """ create a PR on Github
-
-
-    :param str sourceBranch: branch the PR is based on
-    :param str targetRepo: target repository for the PR
-    :param str targetBranch: target for the PR
-    """
-
-    title = "Mirror from gitlab MR: %s" % sourceBranch
-    prDict = dict( head=sourceBranch, base=targetBranch, title=title, sourceRepo=self.repo, targetRepo=targetRepo )
-    if not all( opt in prDict for opt in ( 'branch', 'base', 'title', 'sourceRepo', "FIXME" ) ):
-      self.log.error( "Missing some option in the option dict: %s" , prDict )
-
-    result = curl2Json(parameterDict=prDict, url=self._github("pulls"))
-
-    if 'errors' in result:
-      for error in result['errors']:
-        self.log.error( "ERROR creating PullRequest: %s", error['message'] )
-      return False
-    else:
-      self.log.info( "Created pullrequest" )
-      url = result['html_url']
-      return url
 
 
   def isUpToDate( self ):

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -15,9 +15,10 @@ from mock import patch, MagicMock as Mock, mock_open
 from pprint import pprint
 
 sys.modules['GitTokens'] = Mock(name="GitTokensMock", return_value=Mock(name="returnedMock"))
+sys.modules['requests'] = Mock(name="RequestMock",side_effect=ImportError("nope"))
 
 from tagging.gitinterface import Repo
-from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, curl2Json, authorMapping, AUTHORMAP, checkRate
+from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, _curl2Json as curl2Json, authorMapping, AUTHORMAP, checkRate
 from tagging.parseversion import Version
 
 __RCSID__ = "$Id$"
@@ -36,6 +37,7 @@ def mockCurl(*args, **kwargs):
   logging.error("Kwargs: %r", kwargs )
 
   cmdString = " ".join( getCommands(args) )
+  cmdString += str(kwargs)
   logging.error( "ComdString: %s", cmdString )
   if "/tags" in cmdString:
     logging.error("Returning tags structure")
@@ -300,15 +302,6 @@ class TestHelpers( unittest.TestCase ):
       print args, kwargs
       self.assertEqual( 'curl', args[0][0] )
       self.assertEqual( '-s', args[0][1] )
-
-    with patch("tagging.helperfunctions.subprocess", new=Mock()), \
-         patch("tagging.helperfunctions.subprocess.check_output", new=Mock(return_value="Status: 202")) as check:
-      value = curl2Json( ["-H", "Authorization: token NOTMYGITTOKEN","some","repo", "command"], checkStatusOnly=True)
-      args, kwargs = check.call_args
-      self.assertEqual( value, "Status: 202" )
-      self.assertEqual( 'curl', args[0][0] )
-      self.assertEqual( '-I', args[0][1] )
-      self.assertEqual( '-s', args[0][2] )
 
     with patch("tagging.helperfunctions.subprocess", new=Mock()), \
          patch("tagging.helperfunctions.subprocess.check_output", new=Mock(return_value="arg")) as check:


### PR DESCRIPTION

BEGINRELEASENOTES
- ILCSoftTagging: Implement access to github API via requests module, fixes #48.
   * needs the `requests` module installed, automatic fall back to curl based calls if not present

ENDRELEASENOTES