### PR TITLE
 Enable building the doc for MarlinTPC in the nightly builds and HEAD releases.

### DIFF
--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -203,7 +203,7 @@ ilcsoft.module("PathFinder").download.type="svn"
 
 ilcsoft.install( MarlinTPC( MarlinTPC_version ))
 ilcsoft.module("MarlinTPC").download.type="svn"
-ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='OFF'
+ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
 
 
 ilcsoft.install( BBQ( BBQ_version ))


### PR DESCRIPTION

BEGINRELEASENOTES
- Enable building the doc for MarlinTPC in the nightly builds and HEAD releases.
   - Oliver has fixed building the documentation for MarlinTPC.

ENDRELEASENOTES