### PR TITLE
Release the control of INSTALL_DOC for MarlinTPC, and let TPC gro…

### DIFF
--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -203,7 +203,6 @@ ilcsoft.module("PathFinder").download.type="svn"
 
 ilcsoft.install( MarlinTPC( MarlinTPC_version ))
 ilcsoft.module("MarlinTPC").download.type="svn"
-ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
 
 
 ilcsoft.install( BBQ( BBQ_version ))


### PR DESCRIPTION
…up to decide in MarlinTPC CMakeLists.txt.



BEGINRELEASENOTES
- Release the control of INSTALL_DOC for MarlinTPC.
    - let TPC group to decide in MarlinTPC CMakeLists.txt.
    - nightly build will test and report automatically.

ENDRELEASENOTES