### PR TITLE
Tagging: 

### DIFF
--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -255,7 +255,7 @@ class Repo(object):
 
     self.log.info( "Getting PRs...")
     for pr in mergedPRs:
-      if pr['merged_at'] > lastTagDate:
+      if pr['merged_at'] > lastTagDate and pr['base']['label'].endswith(self.branch):
         self.log.debug( "PR %s was merged _AFTER_ the last tag", pr['number'] )
         self._prsSinceLastTag.append(pr)
       else:
@@ -327,8 +327,8 @@ class Repo(object):
 
     releaseNotesString = "# " + self.newVersion.split("-pre")[0] ## never write comments for new releases
 
-    for date, prs in self._releaseNotes.iteritems():
-      for prID,content in prs.iteritems():
+    for date, prs in sorted(self._releaseNotes.iteritems(), reverse=True):
+      for prID, content in sorted(prs.iteritems(), reverse=True):
         if not content.get( 'notes' ):
           continue
 

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -167,21 +167,14 @@ def _req2Json(url, parameterDict, requestType):
   return req.json()
 
 
-AUTHORMAP = {}
 def authorMapping(username, url):
-  """return the name of the author for given username, if not found query github
+  """return the name of the author for given username, query github
   PR for author via the commands given
   """
   log = logging.getLogger("Author")
-  author = AUTHORMAP.get(username)
-  if author is not None:
-    log.debug( "Found author in map: %s", author)
-    return author
-
-  log.debug( "Checking Commits for Author ")
+  log.debug("Checking Commits for Author")
   commits = curl2Json(url=url)
   author = commits[-1]['commit']['author']['name'] ## use the last commit of PR to get author
-  AUTHORMAP[username] = author
   log.debug( "Found author: %s", author )
   return author
 

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -18,7 +18,7 @@ sys.modules['GitTokens'] = Mock(name="GitTokensMock", return_value=Mock(name="re
 sys.modules['requests'] = Mock(name="RequestMock",side_effect=ImportError("nope"))
 
 from tagging.gitinterface import Repo
-from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, _curl2Json as curl2Json, authorMapping, AUTHORMAP, checkRate
+from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, _curl2Json as curl2Json, authorMapping, checkRate
 from tagging.parseversion import Version
 
 __RCSID__ = "$Id$"
@@ -310,15 +310,9 @@ class TestHelpers( unittest.TestCase ):
 
   def test_getAuthor( self ):
     """ test the mapping of the username to authorname """
-    with patch.dict( AUTHORMAP, {'username': 'User Name'} ):
-      retVal = authorMapping( 'username', ['commands', 'pulls/12/commits'] )
-      self.assertEqual( retVal, 'User Name' )
-
     with patch("tagging.helperfunctions.curl2Json",new=mockCurl):
       retVal = authorMapping( 'username2', ['commands', 'pulls/12/commits'] )
       self.assertEqual( retVal, 'User Name2' )
-      self.assertIn('username2', AUTHORMAP )
-      del AUTHORMAP['username2']
 
   def test_checkRate( self ):
     """ test the checkRate function """


### PR DESCRIPTION

BEGINRELEASENOTES
- Tagging:
  - Fix problem for the username. Caching does not work  when the PR author and commits do not come from the same person
  - PRs are only chosen for the branch that should be tagged
  - Sort release notes by date and PR number

ENDRELEASENOTES