### PR TITLE
Increase the pytest version

### DIFF
--- a/.travis-ci.d/requirements.txt
+++ b/.travis-ci.d/requirements.txt
@@ -4,7 +4,7 @@ simplejson>=3.8.1
 six
 mock>=2
 pylint>=1.4.4
-pytest>=2.8.5
+pytest>=3.6.0
 pytest-cov>=2.2.0
 coverage>=4.0.3
 python-coveralls


### PR DESCRIPTION

BEGINRELEASENOTES
- Increase the pytest version from 2.8.5 to 3.6.0 since it is requred by pytest_cov

ENDRELEASENOTES