### PR TITLE
move https desy svn to http

### DIFF
--- a/ilcsoft/baseilc.py
+++ b/ilcsoft/baseilc.py
@@ -329,7 +329,7 @@ class BaseILC:
                 # if svnurl not set by user generate a default one
                 if( len(self.download.svnurl) == 0 ):
                     # initialize svn settings for desy
-                    self.download.accessmode = "https"
+                    self.download.accessmode = "http"
                     self.download.server = "svnsrv.desy.de"
                     #if( self.download.username == "anonymous" ):
                     #    self.download.root = "public/" + self.download.root

--- a/ilcsoft/gbl.py
+++ b/ilcsoft/gbl.py
@@ -50,7 +50,7 @@ class GBL(BaseILC):
         BaseILC.setMode(self, mode)
 
         self.download.type = 'svn'
-        self.download.svnurl = 'https://svnsrv.desy.de/public/GeneralBrokenLines'
+        self.download.svnurl = 'http://svnsrv.desy.de/public/GeneralBrokenLines'
 
         if( Version( self.version ) == 'HEAD' ):
             self.download.svnurl += '/trunk/cpp'


### PR DESCRIPTION

BEGINRELEASENOTES
- Due to DESY certificate problems in svnsrv move access to http

ENDRELEASENOTES

```sh
2019-02-25 14:29 mpetric@hepexer:~$ svn checkout https://svnsrv.desy.de/public//pathfinder/trunk HEAD
Error validating server certificate for 'https://svnsrv.desy.de:443':
 - The certificate has expired.
Certificate information:
 - Hostname: svnsrv.desy.de
 - Valid: from Oct 22 11:41:08 2014 GMT until Jul  9 23:59:00 2019 GMT
 - Issuer: DESY CA - G02, IT, Deutsches Elektronen-Synchrotron DESY, DE(desy-ca@desy.de)
 - Fingerprint: 2D:0A:AD:F9:2A:CD:8B:FC:2E:0E:A2:E1:41:A6:2F:9C:DD:55:EB:E2
(R)eject, accept (t)emporarily or accept (p)ermanently? 
```