### PR TITLE
Fix CLHEP and Xerces packages

### DIFF
--- a/ilcsoft/clhep.py
+++ b/ilcsoft/clhep.py
@@ -38,7 +38,7 @@ class CLHEP(BaseILC):
                 self.download.url = "http://proj-clhep.web.cern.ch/proj-clhep/export/share/CLHEP/%s/clhep-%s.tgz" \
                         % (self.version, self.version)
             else:
-                self.download.url = "http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/distributions/clhep-%s.tgz" \
+                self.download.url = "http://proj-clhep.web.cern.ch/proj-clhep/dist1/clhep-%s.tgz" \
                         % (self.version,)
 		   
         if( Version( self.version ) >= "2.1.3.0" ):

--- a/releases/v02-00/release-versions.py
+++ b/releases/v02-00/release-versions.py
@@ -224,7 +224,7 @@ Physsim_version = "v00-04-01"
 
 
 # xerces-c (needed by geant4 for building gdml support - required by mokka)
-XERCESC_ROOT_DIR = ilcPath + "/xercesc/3.1.4"
+XercesC_version = "Xerces-C_3_2_2" 
+XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
-XercesC_version = "3.1.4" 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- CLHEP package: updated tarball location
- Xerces-C package: fixed versioning scheme. Updated version to 3.2.2

ENDRELEASENOTES