### PR TITLE
Added install prefix command line option 

### DIFF
--- a/ilcsoft-install
+++ b/ilcsoft-install
@@ -18,6 +18,7 @@ parser.add_option('-d', '--dependencies', action='store_true', help='show depend
 parser.add_option('-i', '--install', action='store_true', help='install the software')
 parser.add_option('-v', '--verbose', action='store_true', dest='verbose', help='run in DEBUG mode')
 parser.add_option('--log-cfg-file', help='file to configure logging settings')
+parser.add_option('--install-prefix', action='store', help='location where to install the software')
 
 (options, args) = parser.parse_args()
 
@@ -63,6 +64,11 @@ ilcsoft_afs_path['gcc48_64bit_ub1404'] = os.path.normpath( os.path.join( ilcsoft
 ilcsoft_afs_path['gcc54_64bit_ub1604'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc54_ub1604' ))
 
 ilcPath = None
+installPrefix = None
+
+if options.install_prefix:
+    installPrefix = options.install_prefix
+
 try:
     import platform
     sizeofint = platform.architecture()[0]
@@ -74,6 +80,8 @@ try:
         arch += "_ub1404"
     if( platf.find("xenial")>0):
         arch += "_ub1604"
+    if( platf.find("bionic")>0):
+        arch += "_ub1804"
     ilcPath = ilcsoft_afs_path[ arch ] + '/'
     gcccheck = platform.python_compiler()
     print gcccheck

--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -21,6 +21,11 @@ if nightlies:
    use_cpp11 = nb_use_cpp11
    print "******************* use_cpp11", use_cpp11
 
+afsPath = None
+try:
+    afsPath = ilcsoft_afs_path[ arch ]
+except KeyError:
+    pass
 
 #===============================================================================
 # use a compiler that knows c++11, run 
@@ -47,7 +52,10 @@ if nightlies:
 # ===========================================================
 #
 
-ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+if installPrefix is None:
+    ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+else:
+    ilcsoft_install_prefix = installPrefix
 #ilcsoft_install_prefix = "/afs/desy.de/project/ilcsoft/sw/x86_64_gcc44_sl6/"
 #ilcsoft_install_prefix = "/nfs/dust/ilc/user/voutsina/testarea/ilcsoft_c11/"
 #ilcsoft_install_prefix = "/scratch/ilcsoft/"
@@ -95,7 +103,7 @@ ilcPath = ilcsoft_install_prefix
 MySQL_version = "5.0.45"
 MySQL_path = ilcPath + "/mysql/" + MySQL_version
 
-if( ilcsoft_afs_path[ arch ].find('_ub') > 0 ):
+if( arch.find('_ub') > 0 ):
     MySQL_path = "/usr"
 
 

--- a/releases/v02-00/release-versions.py
+++ b/releases/v02-00/release-versions.py
@@ -19,6 +19,11 @@ if nightlies:
    use_cpp11 = nb_use_cpp11
    print "******************* use_cpp11", use_cpp11
 
+afsPath = None
+try:
+    afsPath = ilcsoft_afs_path[ arch ]
+except KeyError:
+    pass
 
 #===============================================================================
 # use a compiler that knows c++11, run 
@@ -47,8 +52,10 @@ if nightlies:
 # Modify this path to where you want to install the software
 # ===========================================================
 #
-
-ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+if installPrefix is None:
+    ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+else:
+    ilcsoft_install_prefix = installPrefix
 #ilcsoft_install_prefix = "/cvmfs/ilc.desy.de/sw/x86_64_gcc48_sl6/"
 #ilcsoft_install_prefix = "/scratch/ilcsoft/"
 
@@ -90,7 +97,7 @@ ilcPath = ilcsoft_install_prefix
 MySQL_version = "5.0.45"
 MySQL_path = ilcPath + "/mysql/" + MySQL_version
 
-if( ilcsoft_afs_path[ arch ].find('_ub') > 0 ):
+if( arch.find('_ub') > 0 ):
     MySQL_path = "/usr"
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Added cmd line option `--install-prefix` to `ilcsoft-install` script, to specify install prefix without modifying the scripts manually
- Updated 'version.py' scripts accordingly in `releases` directory

ENDRELEASENOTES