### PR TITLE
XercesC library location (lib64)

### DIFF
--- a/ilcsoft/xercesc.py
+++ b/ilcsoft/xercesc.py
@@ -27,6 +27,9 @@ class XercesC(BaseILC):
                 "lib/libxerces-c.a",
                 "lib/libxerces-c.so",
                 "lib/libxerces-c.dylib",
+                "lib64/libxerces-c.a",
+                "lib64/libxerces-c.so",
+                "lib64/libxerces-c.dylib",
         ]]
     
     def compile(self):


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed possible location of xerces lib during installation process (lib64)

ENDRELEASENOTES