### PR TITLE
dd4hep with boost, nightly tweaks

### DIFF
--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -23,7 +23,6 @@ ilcsoft.envcmake["USE_CXX11"]='OFF'
 ilcsoft.envcmake["CMAKE_CXX_STANDARD"]='14'
 
 #
-ilcsoft.envcmake['CMAKE_CXX_FLAGS']= CMAKE_CXX_FLAGS
 ilcsoft.envcmake["Boost_NO_BOOST_CMAKE"] = 'ON'
 #
 
@@ -79,7 +78,7 @@ ilcsoft.module("MarlinDD4hep").addDependency( [ 'Marlin', 'DD4hep', 'Root', 'DDK
 
 ilcsoft.install( MarlinPKG( "DDMarlinPandora", DDMarlinPandora_version ))
 ilcsoft.module("DDMarlinPandora").addDependency( [ 'Marlin', 'MarlinUtil', 'DD4hep', 'ROOT', 'PandoraPFANew','AIDA', 'MarlinTrk', 'MarlinTrk'] )
-ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 ilcsoft.install( MarlinUtil( MarlinUtil_version ))
 
@@ -94,11 +93,11 @@ ilcsoft.module("PandoraPFANew").envcmake["PANDORA_MONITORING"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["LC_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["EXAMPLE_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["ROOT_DIR"]='${ROOTSYS}/etc/cmake'
-ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 
 ilcsoft.install( MarlinPandora( MarlinPandora_version ))
-ilcsoft.module("MarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("MarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 ilcsoft.install( LCFIVertex( LCFIVertex_version ))
 ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path
@@ -188,7 +187,6 @@ ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_PYROOT"]=0
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]=1
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_BOOST"]=1
 ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_CXX11"] = 'ON'
 
 
 ilcsoft.install( lcgeo( lcgeo_version ))

--- a/builds/release-ilcsoft7.cfg
+++ b/builds/release-ilcsoft7.cfg
@@ -23,7 +23,6 @@ ilcsoft.envcmake["USE_CXX11"]='OFF'
 ilcsoft.envcmake["CMAKE_CXX_STANDARD"]='14'
 
 #
-ilcsoft.envcmake['CMAKE_CXX_FLAGS']= CMAKE_CXX_FLAGS
 ilcsoft.envcmake["Boost_NO_BOOST_CMAKE"] = 'ON'
 #
 
@@ -79,7 +78,7 @@ ilcsoft.module("MarlinDD4hep").addDependency( [ 'Marlin', 'DD4hep', 'Root', 'DDK
 
 ilcsoft.install( MarlinPKG( "DDMarlinPandora", DDMarlinPandora_version ))
 ilcsoft.module("DDMarlinPandora").addDependency( [ 'Marlin', 'MarlinUtil', 'DD4hep', 'ROOT', 'PandoraPFANew','AIDA', 'MarlinTrk', 'MarlinTrk'] )
-ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 ilcsoft.install( MarlinUtil( MarlinUtil_version ))
 
@@ -94,11 +93,11 @@ ilcsoft.module("PandoraPFANew").envcmake["PANDORA_MONITORING"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["LC_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["EXAMPLE_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["ROOT_DIR"]='${ROOTSYS}/etc/cmake'
-ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 
 ilcsoft.install( MarlinPandora( MarlinPandora_version ))
-ilcsoft.module("MarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error -std=c++11'
+ilcsoft.module("MarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 ilcsoft.install( LCFIVertex( LCFIVertex_version ))
 ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path

--- a/builds/release-versions-HEAD.py
+++ b/builds/release-versions-HEAD.py
@@ -12,7 +12,7 @@ today = datetime.date.today()
 
 release_date=today.strftime('%Y-%m-%d')
 
-use_cpp11 = True
+use_cpp11 = False
 
 build_directory = os.getenv("BUILD_PATH", release_date)
 compiler_version = os.getenv("COMPILER_VERSION", "gcc62")
@@ -25,17 +25,12 @@ ilcPath = ilcsoft_install_prefix
 
 Boost_path = "/cvmfs/clicdp.cern.ch/software/Boost/1.62.0/x86_64-slc6-" + compiler_version + "-opt/"
 
-if( use_cpp11 ):
-    CMAKE_CXX_FLAGS = '-Wall -std=c++11'
 
 # ======================= PACKAGE VERSIONS ===================================
 
 Geant4_version =  "10.02.p02" # "10.02.p01" # "10.01" 
 
-if( use_cpp11 ):
-    ROOT_version = "6.06.04"
-else:
-    ROOT_version = "5.34.30" 
+ROOT_version = "6.06.04"
 
 CLHEP_version =  "2.1.4.1" # "2.3.1.1" #  "2.1.4.1"
 

--- a/ilcsoft/dd4hep.py
+++ b/ilcsoft/dd4hep.py
@@ -89,7 +89,7 @@ class DD4hep(BaseILC):
 #        self.envcmds.append("export G4WORKDIR=$DD4HEP")
 
         self.envpath["PATH"].append( "$DD4HEP/bin" )
-        self.envpath["LD_LIBRARY_PATH"].append( "$DD4HEP/lib" )
+        self.envpath["LD_LIBRARY_PATH"].append( "$DD4HEP/lib:$BOOST_ROOT/lib" )
 
         self.envpath["PYTHONPATH"].append( "$DD4HEP/python:$DD4HEP/DDCore/python" )
 


### PR DESCRIPTION

BEGINRELEASENOTES
- dd4hep: add boost library path to post install LD_LIBRARY_PATH
- nightlies: drop explicit use of c++11

ENDRELEASENOTES