### PR TITLE
ILCSoft: export CMAKE_CXX_STANDARD to ILCSoft.cmake

### DIFF
--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -348,6 +348,11 @@ class ILCSoft:
         f.write( "set(CMAKE_CXX_FLAGS_RELWITHDEBINFO \"-O2 -g\" CACHE STRING \"\" FORCE )"  )
         f.write( os.linesep )
 
+        cxxStandard = unicode(self.envcmake.get("CMAKE_CXX_STANDARD", None))
+        if cxxStandard:
+          f.write( 'set(CMAKE_CXX_STANDARD %s CACHE STRING "C++ Standard" FORCE)' % cxxStandard )
+          f.write( os.linesep )
+
         # close file
         f.close()
         f2.close()


### PR DESCRIPTION

BEGINRELEASENOTES
- export CMAKE_CXX_STANDARD to ILCSoft.cmake if it was set at compile time of the release

ENDRELEASENOTES