### PR TITLE
Boost module compilation

### DIFF
--- a/releases/HEAD/release-base.cfg
+++ b/releases/HEAD/release-base.cfg
@@ -158,5 +158,8 @@ sio.envcmake["SIO_MACROS_WITH_EXCEPTION"]='OFF'
 sio.envcmake["SIO_RELEASE_OFAST"]='OFF'
 sio.envcmake["CMAKE_CXX_STANDARD"]=11
 
+# boost
+ilcsoft.install( Boost( Boost_version ) )
+
 # end of configuration file
 

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -327,10 +327,7 @@ ilcsoft.use( CMake( ilcPath + "CMake/" + CMake_version ))
 
 ilcsoft.link( ILCUTIL( ilcPath + "ilcutil/" + ILCUTIL_version ))
 
-
-# use pe-installed boost
-if 'Boost_path' in dir():
-   ilcsoft.use( Boost( Boost_path ) )
+ilcsoft.link( Boost( ilcPath + "boost/" + Boost_version ))
 
 # use pe-installed eigen
 if 'Eigen_path' in dir():

--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -108,7 +108,7 @@ if( platf.lower().find('linux') >= 0 ):
 
 
 #------ boost headers files ------------------------------------------
-Boost_path = "/afs/desy.de/project/ilcsoft/sw/boost/1.58.0"
+# Boost_path = "/afs/desy.de/project/ilcsoft/sw/boost/1.58.0"
 
 #------ Eigen headers files ------------------------------------------
 Eigen_path = "/afs/desy.de/project/ilcsoft/sw/Eigen/3.2.9"
@@ -143,6 +143,8 @@ CMake_version = "3.6.3"
 CED_version = "v01-09-02"
 
 SIO_version = "v00-00-02"
+
+Boost_version = "1.65.0"
 
 # -------------------------------------------
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Change Boost module to download and compile Boost like any other package
- Set Boost version to 1.65.0
- Added Boost module to list packages to install (base) and link (ilcsoft). Only for HEAD version

ENDRELEASENOTES