### PR TITLE
Fix boost install

### DIFF
--- a/ilcsoft/lcfivertex.py
+++ b/ilcsoft/lcfivertex.py
@@ -19,7 +19,7 @@ class LCFIVertex(MarlinPKG):
         MarlinPKG.__init__(self, "LCFIVertex", userInput )
 
         # required modules
-        self.reqmodules = [ "Marlin", "MarlinUtil", "LCIO", "GEAR", "DD4hep"]
+        self.reqmodules = [ "Marlin", "MarlinUtil", "LCIO", "GEAR", "DD4hep", "Boost"]
 
         # optional modules
         self.optmodules = [ "AIDA" ]

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -126,7 +126,7 @@ ilcsoft.module("PandoraPFANew").envcmake["ROOT_DIR"]='${ROOTSYS}/etc/cmake'
 
 
 ilcsoft.install( LCFIVertex( LCFIVertex_version ))
-ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path
+# ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path
 
 ilcsoft.install( CEDViewer( CEDViewer_version )) 
 
@@ -234,7 +234,7 @@ ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_XERCESC"]=0
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_PYROOT"]=0
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]=1
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_BOOST"]=1
-ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
+# ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
 if( use_cpp11 ):
     ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_CXX11"] = 'ON'
 

--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -106,10 +106,6 @@ MySQL_path = ilcPath + "/mysql/" + MySQL_version
 if( platf.lower().find('linux') >= 0 ):
     MySQL_path = "/usr"
 
-
-#------ boost headers files ------------------------------------------
-# Boost_path = "/afs/desy.de/project/ilcsoft/sw/boost/1.58.0"
-
 #------ Eigen headers files ------------------------------------------
 Eigen_path = "/afs/desy.de/project/ilcsoft/sw/Eigen/3.2.9"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Removed references to Boost_path in HEAD scripts
- Fixed LCFIVertex Boost dependency
- Removed CMake var for BOOST_ROOT as CMake can find BOOST using the env variable BOOST_ROOT instead. Done for DD4hep and LCFIVertex

ENDRELEASENOTES