### PR TITLE
Add new location of DD4hep python packages

### DIFF
--- a/ilcsoft/dd4hep.py
+++ b/ilcsoft/dd4hep.py
@@ -9,6 +9,7 @@
 
 # custom imports
 from baseilc import BaseILC
+import sys
 from util import *
 
 
@@ -91,7 +92,7 @@ class DD4hep(BaseILC):
         self.envpath["PATH"].append( "$DD4HEP/bin" )
         self.envpath["LD_LIBRARY_PATH"].append( "$DD4HEP/lib:$BOOST_ROOT/lib" )
 
-        self.envpath["PYTHONPATH"].append( "$DD4HEP/python:$DD4HEP/DDCore/python" )
+        self.envpath["PYTHONPATH"].append("$DD4HEP/lib/python%s.%s/site-packages:$DD4HEP/python" % (sys.version_info[0], sys.version_info[1]))
 
 #       self.envcmds.append('test -r ${G4ENV_INIT} && { cd $(dirname ${G4ENV_INIT}) ; . ./$(basename ${G4ENV_INIT}) ; cd $OLDPWD ; }')
         

--- a/ilcsoft/dd4hep.py
+++ b/ilcsoft/dd4hep.py
@@ -91,8 +91,10 @@ class DD4hep(BaseILC):
 
         self.envpath["PATH"].append( "$DD4HEP/bin" )
         self.envpath["LD_LIBRARY_PATH"].append( "$DD4HEP/lib:$BOOST_ROOT/lib" )
-
-        self.envpath["PYTHONPATH"].append("$DD4HEP/lib/python%s.%s/site-packages:$DD4HEP/python" % (sys.version_info[0], sys.version_info[1]))
+        if( Version( self.version ) <= '1.10' ):
+            self.envpath["PYTHONPATH"].append( "$DD4HEP/python:$DD4HEP/DDCore/python" )
+        else:
+            self.envpath["PYTHONPATH"].append("$DD4HEP/lib/python%s.%s/site-packages" % (sys.version_info[0], sys.version_info[1]))
 
 #       self.envcmds.append('test -r ${G4ENV_INIT} && { cd $(dirname ${G4ENV_INIT}) ; . ./$(basename ${G4ENV_INIT}) ; cd $OLDPWD ; }')
         


### PR DESCRIPTION

BEGINRELEASENOTES
- set `PYTHONPATH` for DD4hep to `$DD4HEP/lib/pythonX.Y/site-packages:$DD4HEP/python` to align with AIDASoft/DD4hep#572 

ENDRELEASENOTES