### PR TITLE
Fix usage of cmakeconfig variable

### DIFF
--- a/ilcsoft/geant4.py
+++ b/ilcsoft/geant4.py
@@ -87,7 +87,7 @@ class Geant4(BaseILC):
 
         v = Version( self.version )
         v = "%s.%s.%s" % ( v[0], v[1], v[2] )
-        self.cmakeconfig = self.installPath + "/lib/Geant4-" + v  + "; " + self.installPath + "/lib64/Geant4-" + v
+        self.cmakeconfig = self.installPath + "/lib/Geant4-" + v  + ";" + self.installPath + "/lib64/Geant4-" + v
 
     def compile(self):
         """ compile Geant4 """

--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -280,7 +280,7 @@ class ILCSoft:
                     else:
                         configpath = mod.installPath
                 f.write( configpath + ';' + os.linesep )
-                f2.write( configpath + ':\\' + os.linesep )
+                f2.write( configpath.replace(';', ':') + ':\\' + os.linesep )
 
                 #f.write( "MARK_AS_ADVANCED( " + modname + "_DIR )" + os.linesep  )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed export of `cmakeconfig` in shell script
- Fixed additional whitespace in geant4 `cmakeconfig` variable

ENDRELEASENOTES

Fixes #80 