### PR TITLE
Fix clicdp nightlies

### DIFF
--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -44,9 +44,9 @@ build_option="opt"
 ilcsoft.use( MySQL("/cvmfs/clicdp.cern.ch/software/MySQL/5.7.16/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 ilcsoft.use( FastJet( "/cvmfs/clicdp.cern.ch/software/FastJet/3.3.2/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 ilcsoft.use( XercesC( "/cvmfs/clicdp.cern.ch/software/Xerces-C/3.1.4/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
-ilcsoft.use( Geant4( "/cvmfs/clicdp.cern.ch/software/Geant4/10.02.p02/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
+ilcsoft.use( Geant4( "/cvmfs/clicdp.cern.ch/software/Geant4/10.02.p02/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, '10.02.p02' ))
 ilcsoft.use( ROOT( "/cvmfs/clicdp.cern.ch/software/ROOT/6.08.00/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
-ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.1.1/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
+ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.1.1/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, '2.3.1.1' ))
 ilcsoft.use( GSL( "/cvmfs/clicdp.cern.ch/software/GSL/2.2.1/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 
 #ilcsoft.use( LCIO( "/cvmfs/clicdp.cern.ch/software/LCIO/2.7.2/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))

--- a/ilcsoft/baseilc.py
+++ b/ilcsoft/baseilc.py
@@ -111,7 +111,7 @@ class BaseILC:
                     print
 
         if( self.mode == "use" ):
-            print "   + [ " + self.installPath + " ]",
+            print "   + [ " + self.installPath + " - version: " + self.version + " ]",
             if self.useLink:
                 print " -> [ "+ self.realPath() + " ]",
             print
@@ -248,7 +248,8 @@ class BaseILC:
                 # 1st case: full path to installation is given
                 self.installPath = fixPath(self.__userInput)
                 # extract version from path
-                self.version = basename( self.installPath )
+                if(  not hasattr(self, 'version') ):
+                    self.version = basename( self.installPath )
                 # 2nd case: use( Mod( "vXX-XX" ) is given
                 if( not self.checkInstall() ):
                     self.version = self.__userInput

--- a/ilcsoft/clhep.py
+++ b/ilcsoft/clhep.py
@@ -15,15 +15,17 @@ from util import *
 class CLHEP(BaseILC):
     """ Responsible for the CLHEP installation process. """
     
-    def __init__(self, userInput):
+    def __init__(self, userInput, version=''):
         BaseILC.__init__(self, userInput, "CLHEP", "CLHEP")
 
         self.download.supportHEAD = False
         self.download.supportedTypes = ["wget"]
 
         self.reqfiles = [ ["lib/libCLHEP.a", "lib/libCLHEP.so", "lib64/libCLHEP.so", "lib/libCLHEP.dylib"] ]
-        
-			
+
+        if(len(version)>0):
+            self.version = version
+
     def setMode(self, mode):
         BaseILC.setMode(self, mode)
         
@@ -43,7 +45,7 @@ class CLHEP(BaseILC):
 		   
         if( Version( self.version ) >= "2.1.3.0" ):
             self.hasCMakeBuildSupport = True
-            self.cmakeconfig = self.installPath + "/lib/CLHEP-" + self.version
+            self.cmakeconfig = self.installPath + "/lib/CLHEP-" +  self.version
 
 
     def downloadSources(self):

--- a/ilcsoft/geant4.py
+++ b/ilcsoft/geant4.py
@@ -15,7 +15,7 @@ from util import *
 class Geant4(BaseILC):
     """ Responsible for the Geant4 configuration process. """
     
-    def __init__(self, userInput):
+    def __init__(self, userInput, version=''):
         BaseILC.__init__(self, userInput, "Geant4", "geant4")
 
         #self.installSupport = False
@@ -39,6 +39,9 @@ class Geant4(BaseILC):
         ] ]
 
         self.optmodules = [ 'Qt5', 'CLHEP' , "XercesC"]
+
+        if(len(version)>0):
+            self.version = version
 
     def createLink(self):
         BaseILC.createLink(self)


### PR DESCRIPTION

BEGINRELEASENOTES
- fix CLICdp nightly builds
    - after #78 the nightly builds for CLICdp were broken due to non-standard path naming conventions ( having the machine/compiler as lowest directory rather than the version)
     - this is fixed by allowing to set the `version` as extra parameter for geant4 and clhep
            - these packages need the correct version for specifying the path to the CMakeConfig script
- should fix #80 

ENDRELEASENOTES