### PR TITLE
Missing build_env.sh sourcing

### DIFF
--- a/ilcsoft/kaltest.py
+++ b/ilcsoft/kaltest.py
@@ -30,7 +30,7 @@ class KalTest(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -45,11 +45,11 @@ class MarlinPKG(BaseILC):
             tryunlink( "CMakeCache.txt" )
 
         # build software
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
 
         #if( os.system( ". ../../../init_ilcsoft.sh ; make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):
-        if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to compile!!" )
 
         if( os.system( "make install" ) != 0 ):


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed missing build_env.sh sourcing before configure in packages `kaltest` and `marlinpkg`

ENDRELEASENOTES