### PR TITLE
Missing build_env.sh source. Second round

### DIFF
--- a/ilcsoft/bbq.py
+++ b/ilcsoft/bbq.py
@@ -34,7 +34,7 @@ class BBQ(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/ddkaltest.py
+++ b/ilcsoft/ddkaltest.py
@@ -40,7 +40,7 @@ class DDKalTest(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/gbl.py
+++ b/ilcsoft/gbl.py
@@ -30,7 +30,7 @@ class GBL(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/kaltest.py
+++ b/ilcsoft/kaltest.py
@@ -73,7 +73,7 @@ class KalDet(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/kitrack.py
+++ b/ilcsoft/kitrack.py
@@ -31,7 +31,7 @@ class KiTrack(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):
@@ -61,7 +61,7 @@ class KiTrackMarlin(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/marlintrk.py
+++ b/ilcsoft/marlintrk.py
@@ -33,7 +33,7 @@ class MarlinTrk(BaseILC):
         if( self.rebuild ):
             tryunlink( "CMakeCache.txt" )
         
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
         
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/pathfinder.py
+++ b/ilcsoft/pathfinder.py
@@ -33,7 +33,7 @@ class PathFinder(BaseILC):
             tryunlink( "CMakeCache.txt" )
 
         # build software
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
 
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/raida.py
+++ b/ilcsoft/raida.py
@@ -35,7 +35,7 @@ class RAIDA(BaseILC):
             tryunlink( "CMakeCache.txt" )
 
         # build software
-        if( os.system( self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
+        if( os.system( ". ../build_env.sh ; " + self.genCMakeCmd() + " 2>&1 | tee -a " + self.logfile ) != 0 ):
             self.abort( "failed to configure!!" )
 
         if( os.system( "make ${MAKEOPTS} 2>&1 | tee -a " + self.logfile ) != 0 ):


### PR DESCRIPTION
BEGINRELEASENOTES
- Added missing source of build_env.sh before running CMake command in various packages:
   - BBQ, DDKalTest, GBL, KalTest, KiTrack, KiTrackMarlin, MarlinTrk, pathfinder, RAIDA

ENDRELEASENOTES

Fixes #80 