### PR TITLE
Fix el7

### DIFF
--- a/ilcsoft-install
+++ b/ilcsoft-install
@@ -65,6 +65,7 @@ ilcsoft_afs_path['gcc44_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_pa
 ilcsoft_afs_path['gcc48_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc48_sl6' ))
 ilcsoft_afs_path['gcc49_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc49_sl6' ))
 ilcsoft_afs_path['gcc82_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc82_sl6' ))
+ilcsoft_afs_path['gcc82_64bit_centos7'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc82_centos7' ))
 ilcsoft_afs_path['gcc46_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc46_ub1204' ))
 ilcsoft_afs_path['gcc48_64bit_ub1404'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc48_ub1404' ))
 ilcsoft_afs_path['gcc54_64bit_ub1604'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc54_ub1604' ))
@@ -88,6 +89,8 @@ try:
         arch += "_ub1604"
     if( platf.find("bionic")>0):
         arch += "_ub1804"
+    if( platf.find("centos-7")>0):
+        arch += "_centos7"
     ilcPath = ilcsoft_afs_path[ arch ] + '/'
     gcccheck = platform.python_compiler()
     print gcccheck

--- a/scripts/use_gcc82_cvmfs.sh
+++ b/scripts/use_gcc82_cvmfs.sh
@@ -3,9 +3,6 @@ source /cvmfs/sft.cern.ch/lcg/releases/gcc/8.2.0/x86_64-slc6/setup.sh
 export PATH=/cvmfs/sft.cern.ch/lcg/releases/LCG_96/Python/2.7.16/x86_64-slc6-gcc8-opt/bin:$PATH
 export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/LCG_96/Python/2.7.16/x86_64-slc6-gcc8-opt/lib:$LD_LIBRARY_PATH
 
-# --- use correct tbb for ROOT
-export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/tbb/2019_U1-5939b/x86_64-slc6-gcc8-opt/lib/:$LD_LIBRARY_PATH 
-
 
 # --- use a suitable mysql
 

--- a/scripts/use_gcc82_cvmfs_el7.sh
+++ b/scripts/use_gcc82_cvmfs_el7.sh
@@ -1,0 +1,11 @@
+#---- use gcc and python from SFT in cvmfs
+source /cvmfs/sft.cern.ch/lcg/releases/gcc/8.2.0/x86_64-centos7/setup.sh
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/LCG_96/Python/2.7.16/x86_64-centos7-gcc8-opt/bin:$PATH
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/LCG_96/Python/2.7.16/x86_64-centos7-gcc8-opt/lib:$LD_LIBRARY_PATH
+
+# --- use a suitable mysql
+export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/5.7.26-c3e26/x86_64-centos7-gcc8-opt
+
+# --- use a recent version of git
+export PATH=/cvmfs/sft.cern.ch/lcg/contrib/git/2.17.0/x86_64-centos7/bin:$PATH
+


### PR DESCRIPTION

BEGINRELEASENOTES
- allow standard installations for centos7
      - add `./scripts/use_gcc82_cvmfs_el7.sh`
      - add default afs path

ENDRELEASENOTES