### PR TITLE
Missing CMake support switch in nightly build config

### DIFF
--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -121,6 +121,7 @@ ilcsoft.install( MarlinPKG( "LCTuple", LCTuple_version ))
 ilcsoft.module("LCTuple").addDependency( [ 'LCIO', 'Marlin', 'ROOT'] )
 
 ilcsoft.install( MarlinPKG( "MarlinKinfit", MarlinKinfit_version ))
+ilcsoft.module("MarlinKinfit").hasCMakeFindSupport=True
 ilcsoft.module("MarlinKinfit").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin'] )
 
 ilcsoft.install( MarlinTrk( MarlinTrk_version ))
@@ -145,6 +146,8 @@ ilcsoft.install( MarlinPKG( "Physsim", Physsim_version ))
 ilcsoft.module("Physsim").addDependency( [ 'LCIO', 'ROOT', 'Marlin' ] )
 
 ilcsoft.install( MarlinPKG( "FCalClusterer", FCalClusterer_version ))
+# Special case: BeamCalRecoConfig.cmake is generated in FCalClusterer
+ilcsoft.module("FCalClusterer").hasCMakeFindSupport=True
 ilcsoft.module("FCalClusterer").download.supportedTypes = [ "GitHub" ]
 ilcsoft.module("FCalClusterer").download.gituser = 'FCALSW'
 ilcsoft.module("FCalClusterer").download.gitrepo = 'FCalClusterer'
@@ -156,6 +159,7 @@ ilcsoft.install( MarlinPKG( "ForwardTracking", ForwardTracking_version ))
 ilcsoft.module("ForwardTracking").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'MarlinTrk'] )
 
 ilcsoft.install( MarlinPKG( "Clupatra", Clupatra_version ))
+ilcsoft.module("Clupatra").hasCMakeFindSupport=True
 ilcsoft.module("Clupatra").addDependency( [ 'LCIO', 'ROOT', 'RAIDA', 'Marlin', 'MarlinUtil', 'KalTest', 'MarlinTrk' ] )
 
 ilcsoft.install( PathFinder( PathFinder_version ))


### PR DESCRIPTION
BEGINRELEASENOTES
- Missing CMake support switch in nightly build config. Packages affected:
   - MarlinKinfit, FCalClusterer, Clupatra

ENDRELEASENOTES

Fixes #80 