### PR TITLE
Fix nightly build for gcc7 config

### DIFF
--- a/builds/release-ilcsoft7.cfg
+++ b/builds/release-ilcsoft7.cfg
@@ -120,6 +120,7 @@ ilcsoft.install( MarlinPKG( "LCTuple", LCTuple_version ))
 ilcsoft.module("LCTuple").addDependency( [ 'LCIO', 'Marlin', 'ROOT'] )
 
 ilcsoft.install( MarlinPKG( "MarlinKinfit", MarlinKinfit_version ))
+ilcsoft.module("MarlinKinfit").hasCMakeFindSupport=True
 ilcsoft.module("MarlinKinfit").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin'] )
 
 ilcsoft.install( MarlinTrk( MarlinTrk_version ))
@@ -144,6 +145,8 @@ ilcsoft.install( MarlinPKG( "Physsim", Physsim_version ))
 ilcsoft.module("Physsim").addDependency( [ 'LCIO', 'ROOT', 'Marlin' ] )
 
 ilcsoft.install( MarlinPKG( "FCalClusterer", FCalClusterer_version ))
+# Special case: BeamCalRecoConfig.cmake is generated in FCalClusterer
+ilcsoft.module("FCalClusterer").hasCMakeFindSupport=True
 ilcsoft.module("FCalClusterer").download.supportedTypes = [ "GitHub" ]
 ilcsoft.module("FCalClusterer").download.gituser = 'FCALSW'
 ilcsoft.module("FCalClusterer").download.gitrepo = 'FCalClusterer'
@@ -155,6 +158,7 @@ ilcsoft.install( MarlinPKG( "ForwardTracking", ForwardTracking_version ))
 ilcsoft.module("ForwardTracking").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'MarlinTrk'] )
 
 ilcsoft.install( MarlinPKG( "Clupatra", Clupatra_version ))
+ilcsoft.module("Clupatra").hasCMakeFindSupport=True
 ilcsoft.module("Clupatra").addDependency( [ 'LCIO', 'ROOT', 'RAIDA', 'Marlin', 'MarlinUtil', 'KalTest', 'MarlinTrk' ] )
 
 ilcsoft.install( PathFinder( PathFinder_version ))


### PR DESCRIPTION

BEGINRELEASENOTES
- Missing CMake support switch in nightly build config for gcc7. Packages affected:
   - MarlinKinfit, FCalClusterer, Clupatra


ENDRELEASENOTES