### PR TITLE
Nightly build fix, round 3

### DIFF
--- a/builds/release-ilcsoft7.cfg
+++ b/builds/release-ilcsoft7.cfg
@@ -44,9 +44,9 @@ build_option="opt"
 ilcsoft.use( MySQL("/cvmfs/clicdp.cern.ch/software/MySQL/5.7.16/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 ilcsoft.use( FastJet( "/cvmfs/clicdp.cern.ch/software/FastJet/3.3.0/x86_64-" + flavour + "-gcc7-" + build_option ))
 ilcsoft.use( XercesC( "/cvmfs/clicdp.cern.ch/software/Xerces-C/3.2.0/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
-ilcsoft.use( Geant4( "/cvmfs/clicdp.cern.ch/software/Geant4/10.03.p03/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
+ilcsoft.use( Geant4( "/cvmfs/clicdp.cern.ch/software/Geant4/10.03.p03/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, '10.03.p03'  ))
 ilcsoft.use( ROOT( "/cvmfs/clicdp.cern.ch/software/ROOT/6.12.06/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
-ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.4.3/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
+ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.4.3/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, , '2.3.4.3' ))
 ilcsoft.use( GSL( "/cvmfs/clicdp.cern.ch/software/GSL/2.4/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 
 #ilcsoft.use( LCIO( "/cvmfs/clicdp.cern.ch/software/LCIO/2.7.2/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))


### PR DESCRIPTION

BEGINRELEASENOTES
- Same fixes as in #84 but for `release-ilcsoft7.cfg`
    - Missing fix of Geant4 and CLHEP version not set

ENDRELEASENOTES