### PR TITLE
Xerces tag fix

### DIFF
--- a/releases/HEAD/release-versions-HEAD.py
+++ b/releases/HEAD/release-versions-HEAD.py
@@ -165,7 +165,7 @@ FastJet_version = "3.2.1"
 FastJetcontrib_version = "1.025"
 
 # xerces-c (needed by geant4 for building gdml support - required by mokka)
-XercesC_version = "Xerces-C_3_2_2"
+XercesC_version = "v3.2.2"
 XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 # -------------------------------------------

--- a/releases/v02-01/release-versions.py
+++ b/releases/v02-01/release-versions.py
@@ -249,5 +249,5 @@ Physsim_version = "v00-04-01"
 
 
 # xerces-c (needed by geant4 for building gdml support - required by mokka)
-XercesC_version = "Xerces-C_3_2_2"
+XercesC_version = "v3.2.2"
 XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed XercesC version tag name. Use the same version `v3.2.2`

ENDRELEASENOTES

Fixes #95 