### PR TITLE
MarlinTPC is back

### DIFF
--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -203,9 +203,9 @@ ilcsoft.module("LICH").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinUtil' ]
 ilcsoft.install( PathFinder( PathFinder_version ))
 ilcsoft.module("PathFinder").download.type="svn"
 
-#ilcsoft.install( MarlinTPC( MarlinTPC_version ))
-#ilcsoft.module("MarlinTPC").download.type="svn"
-#ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
+ilcsoft.install( MarlinTPC( MarlinTPC_version ))
+ilcsoft.module("MarlinTPC").download.type="svn"
+ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
 
 
 ilcsoft.install( BBQ( BBQ_version ))

--- a/releases/v02-01/release-ilcsoft.cfg
+++ b/releases/v02-01/release-ilcsoft.cfg
@@ -210,9 +210,9 @@ ilcsoft.module("LICH").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinUtil' ]
 ilcsoft.install( PathFinder( PathFinder_version ))
 ilcsoft.module("PathFinder").download.type="svn"
 
-# ilcsoft.install( MarlinTPC( MarlinTPC_version ))
-# ilcsoft.module("MarlinTPC").download.type="svn"
-# ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='OFF'
+ilcsoft.install( MarlinTPC( MarlinTPC_version ))
+ilcsoft.module("MarlinTPC").download.type="svn"
+ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='OFF'
 
 ilcsoft.install( BBQ( BBQ_version ))
 ilcsoft.module("BBQ").download.type="svn"

--- a/releases/v02-01/release-versions.py
+++ b/releases/v02-01/release-versions.py
@@ -230,7 +230,7 @@ Overlay_version = "v00-22"
 
 PathFinder_version = "v00-06-01"
 
-MarlinTPC_version = "v01-05"
+MarlinTPC_version = "v01-06"
 
 LCTuple_version = "v01-12"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Include MarlinTPC software again in the iLCSoft stack
- Set MarlinTPC version to `v01-06`

ENDRELEASENOTES