### PR TITLE
update DD4hep version to v01-11-02

### DIFF
--- a/releases/v02-01/release-versions.py
+++ b/releases/v02-01/release-versions.py
@@ -240,8 +240,8 @@ Druid_version = "2.2"
 
 Garlic_version = "v03-01"
 
-DD4hep_version = "v01-11-01"
-DD4hepExamples_version = "v01-11-01"
+DD4hep_version = "v01-11-02"
+DD4hepExamples_version = "v01-11-02"
 
 lcgeo_version = "v00-16-06"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- update DD4hep version to v01-11-02 for ilcsoft release v02-01

ENDRELEASENOTES