### PR TITLE
increase timeout for g4 data download

### DIFF
--- a/releases/HEAD/release-base.cfg
+++ b/releases/HEAD/release-base.cfg
@@ -120,6 +120,7 @@ geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
 geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
 geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
 geant4.envcmake["GEANT4_BUILD_CXXSTD"]='c++' + str(cxx_standard)
+geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='30000'
 
 #geant4.envcmake["QT_QMAKE_EXECUTABLE"]=/path/to/qmake
 if 'XERCESC_ROOT_DIR' in dir():

--- a/releases/HEAD/release-base.cfg
+++ b/releases/HEAD/release-base.cfg
@@ -120,7 +120,7 @@ geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
 geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
 geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
 geant4.envcmake["GEANT4_BUILD_CXXSTD"]='c++' + str(cxx_standard)
-geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='30000'
+geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='7200'
 
 #geant4.envcmake["QT_QMAKE_EXECUTABLE"]=/path/to/qmake
 if 'XERCESC_ROOT_DIR' in dir():

--- a/releases/v02-01/release-base.cfg
+++ b/releases/v02-01/release-base.cfg
@@ -120,6 +120,7 @@ geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
 geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
 geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
 geant4.envcmake["GEANT4_BUILD_CXXSTD"]='c++' + str(cxx_standard)
+geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='7200'
 
 #geant4.envcmake["QT_QMAKE_EXECUTABLE"]=/path/to/qmake
 if 'XERCESC_ROOT_DIR' in dir():


### PR DESCRIPTION
BEGINRELEASENOTES
- increase timeout to prevent installation failures due to slow G4 data downloads (default is 1500 s)
ENDRELEASENOTES