### PR TITLE
add SIO library to LCG releases and nightlies

### DIFF
--- a/builds/release-ilcsoft-lcg.cfg
+++ b/builds/release-ilcsoft-lcg.cfg
@@ -180,6 +180,11 @@ ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]=1
 ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_BOOST"]=1
 ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
 
+ilcsoft.install( SIO( SIO_version ))
+ilcsoft.module("SIO").download.type="GitHub"
+ilcsoft.module("SIO").download.gituser="iLCSoft"
+ilcsoft.module("SIO").download.gitrepo="SIO"
+
 ilcsoft.install( LCIO( LCIO_version ))
 ilcsoft.module("LCIO").envcmake['BUILD_ROOTDICT']='ON'
 ilcsoft.module("LCIO").download.type="GitHub"

--- a/builds/release-ilcsoft.cfg
+++ b/builds/release-ilcsoft.cfg
@@ -49,7 +49,11 @@ ilcsoft.use( ROOT( "/cvmfs/clicdp.cern.ch/software/ROOT/6.08.00/x86_64-" + flavo
 ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.1.1/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, '2.3.1.1' ))
 ilcsoft.use( GSL( "/cvmfs/clicdp.cern.ch/software/GSL/2.2.1/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 
-#ilcsoft.use( LCIO( "/cvmfs/clicdp.cern.ch/software/LCIO/2.7.2/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
+ilcsoft.install( SIO( SIO_version ))
+ilcsoft.module("SIO").download.type="GitHub"
+ilcsoft.module("SIO").download.gituser="iLCSoft"
+ilcsoft.module("SIO").download.gitrepo="SIO"
+
 ilcsoft.install( LCIO( LCIO_version ))
 ilcsoft.module("LCIO").envcmake['BUILD_ROOTDICT']='ON'
 ilcsoft.module("LCIO").download.type="GitHub"

--- a/builds/release-ilcsoft7.cfg
+++ b/builds/release-ilcsoft7.cfg
@@ -49,6 +49,11 @@ ilcsoft.use( ROOT( "/cvmfs/clicdp.cern.ch/software/ROOT/6.12.06/x86_64-" + flavo
 ilcsoft.use( CLHEP( "/cvmfs/clicdp.cern.ch/software/CLHEP/2.3.4.3/x86_64-" + flavour + "-" + compiler_version + "-" + build_option, '2.3.4.3' ))
 ilcsoft.use( GSL( "/cvmfs/clicdp.cern.ch/software/GSL/2.4/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 
+ilcsoft.install( SIO( SIO_version ))
+ilcsoft.module("SIO").download.type="GitHub"
+ilcsoft.module("SIO").download.gituser="iLCSoft"
+ilcsoft.module("SIO").download.gitrepo="SIO"
+
 #ilcsoft.use( LCIO( "/cvmfs/clicdp.cern.ch/software/LCIO/2.7.2/x86_64-" + flavour + "-" + compiler_version + "-" + build_option ))
 ilcsoft.install( LCIO( LCIO_version ))
 ilcsoft.module("LCIO").envcmake['BUILD_ROOTDICT']='ON'

--- a/builds/release-versions-HEAD.py
+++ b/builds/release-versions-HEAD.py
@@ -43,6 +43,7 @@ CMake_version = "3.4.3" # "2.8.5"
 CED_version = "HEAD"
 
 # -------------------------------------------
+SIO_version = "HEAD"
 
 LCIO_version = "HEAD" # "v02-06"
 

--- a/builds/release-versions-HEAD7.py
+++ b/builds/release-versions-HEAD7.py
@@ -43,6 +43,7 @@ CMake_version = "3.14.3" # "2.8.5"
 CED_version = "HEAD"
 
 # -------------------------------------------
+SIO_version = "HEAD"
 
 LCIO_version = "HEAD" # "v02-06"
 

--- a/builds/release-versions-lcg.py
+++ b/builds/release-versions-lcg.py
@@ -43,6 +43,7 @@ CMake_version = "3.14.3" # "2.8.5"
 CED_version = "HEAD"
 
 # -------------------------------------------
+SIO_version = "HEAD"
 
 LCIO_version = "HEAD" # "v02-06"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- add standalone SIO library to LCG releases and nightlies
      - will be needed for LCIO and PODIO

ENDRELEASENOTES