### PR TITLE
Upgraded iLCUtil version

### DIFF
--- a/doc/release_notes_ilcsoft_v02-02.md
+++ b/doc/release_notes_ilcsoft_v02-02.md
@@ -12,6 +12,12 @@ None
 
 ## Packages changed wrt. to v02-01-02:
 
+# iLCUtil v01-06-01
+
+* 2020-05-13 Frank Gaede ([PR#17](https://github.com/iLCSoft/iLCUtil/pull/17))
+  - fix FindMySQL.cmake
+          - add correct search path for Ubuntu (>=18.04)
+
 # LCIO v02-15
 
 * 2020-08-13 Frank Gaede ([PR#102](https://github.com/ilcsoft/lcio/pull/102))

--- a/releases/v02-02/release-versions.py
+++ b/releases/v02-02/release-versions.py
@@ -157,7 +157,7 @@ GEAR_version = "v01-09"
 
 CondDBMySQL_version = "CondDBMySQL_ILC-0-9-7"
 
-ILCUTIL_version = "v01-06"
+ILCUTIL_version = "v01-06-01"
 
 MarlinFastJet_version = "v00-05-02"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Upgraded iLCUtil to v01-06-01 (find mysql fix for ubuntu). 
- Updated v02-02 release notes

ENDRELEASENOTES