### PR TITLE
Add proper cvmfs repo to be able to install it

### DIFF
--- a/docker/cvmfs-install/Dockerfile.cvmfs-install.centos7
+++ b/docker/cvmfs-install/Dockerfile.cvmfs-install.centos7
@@ -5,6 +5,8 @@ LABEL maintainer="remi.ete@desy.de"
 LABEL description="Image to install iLCSoft on CVMFS for centos7 flavor"
 LABEL os="centos7"
 
+RUN yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
+
 RUN yum install -y cvmfs \
     	 wget \
 		   emacs \


### PR DESCRIPTION
BEGINRELEASENOTES
- Add proper cvmfs repository for installing cvmfs in Docker image

BEGINRELEASENOTES

Without this yum will not be able to install cmvfs because it will not
be available