### PR TITLE
Include fixes for Overlay package into release 02-02-01

### DIFF
--- a/doc/release_notes_ilcsoft_v02-02-01.md
+++ b/doc/release_notes_ilcsoft_v02-02-01.md
@@ -13,6 +13,20 @@ None
 
 ## Packages changed wrt. to v02-02:
 
+# Overlay v00-22-02
+
+* 2021-03-01 tmadlener ([PR#22](https://github.com/iLCSoft/Overlay/pull/22))
+  - Migrate CI to github actions
+
+* 2021-03-01 hegarcia ([PR#21](https://github.com/iLCSoft/Overlay/pull/21))
+  - fix for merging SimCalorimeterHits in Merger.cc
+        - Adding length and position to the MC Contributions for use in the SDHCALDigi.
+
+# Overlay v00-22-01
+
+* 2020-07-09 Placido Fernandez Declara ([PR#20](https://github.com/iLCSoft/Overlay/pull/20))
+  - OverlayTiming/OverlayTimingGeneric: Fixed accessing empty file name for background file
+
 # MarlinReco v01-29
 
 * 2021-02-26 Bohdan Dudar ([PR#88](https://github.com/iLCSoft/MarlinReco/pull/88))

--- a/releases/v02-02/release-versions.py
+++ b/releases/v02-02/release-versions.py
@@ -224,7 +224,7 @@ PandoraAnalysis_version = "v02-00-01"
 
 CEDViewer_version = "v01-17-01"
 
-Overlay_version = "v00-22"
+Overlay_version = "v00-22-02"
 
 PathFinder_version = "v00-06-01"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Upgrade Overlay to v00-22-02

ENDRELEASENOTES

To be included still in the v02-02-01 release