### PR TITLE
Update install paths for libsio

### DIFF
--- a/ilcsoft/sio.py
+++ b/ilcsoft/sio.py
@@ -18,7 +18,8 @@ class SIO(BaseILC):
     def __init__(self, userInput):
         BaseILC.__init__(self, userInput, "SIO", "sio")
         
-        self.reqfiles = [ ["lib/libsio.a", "lib/libsio.so", "lib/libsio.dylib"] ]
+        self.reqfiles = [ ["lib64/libsio.a", "lib64/libsio.so",
+                          "lib/libsio.a", "lib/libsio.so", "lib/libsio.dylib" ] ]
         self.reqmodules = [ "CMake" ]
 
         # supported download types


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that `libsio` is found after CMake updates to sio

ENDRELEASENOTES

iLCSoft/SIO/#15 introduced a small change to where `libsio` will be installed. This makes sure that the install script still recognizes this as a successful install.