### PR TITLE
Bump MarlinReco version once more before release

### DIFF
--- a/doc/release_notes_ilcsoft_v02-02-01.md
+++ b/doc/release_notes_ilcsoft_v02-02-01.md
@@ -26,6 +26,17 @@ None
 
 * 2020-07-09 Placido Fernandez Declara ([PR#20](https://github.com/iLCSoft/Overlay/pull/20))
   - OverlayTiming/OverlayTimingGeneric: Fixed accessing empty file name for background file
+  
+# MarlinReco v01-30
+
+* 2021-03-03 Remi Ete ([PR#83](https://github.com/iLCSoft/MarlinReco/pull/83))
+  - RealisticCaloDigi: Added new option for energy/charge and time integration
+    - deal with slow/fast shaper of ROC chips and time estimate
+    - new processor parameters:
+       - **integrationMethod**: "Standard" for old implementation (default) or "ROC" emulating the behavior of ROC chip.
+       - **fastShaper**: fast shaper time, unit in ns. Only for ROC method
+       - **slowShaper**: slow shaper time, unit in ns. Only for ROC method
+       - **timingResolution**: optional time resolution gaussian smearing to apply, unit . Only apply is > 0. Default is 0 (no smearing)
 
 # MarlinReco v01-29
 

--- a/releases/v02-02/release-versions.py
+++ b/releases/v02-02/release-versions.py
@@ -204,7 +204,7 @@ Marlin_version = "v01-17-01"
 
 MarlinDD4hep_version = "v00-06"
 
-MarlinReco_version = "v01-29"
+MarlinReco_version = "v01-30"
 
 ILDPerformance_version = "v01-09"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Update MarlineReco version to v01-30

ENDRELEASENOTES

To still include the updated calo digitization in the v02-02-01 release.