### PR TITLE
Update Dockerfile for producing the cvmfs-install container image

### DIFF
--- a/docker/cvmfs-install/Dockerfile.cvmfs-install.centos7
+++ b/docker/cvmfs-install/Dockerfile.cvmfs-install.centos7
@@ -5,9 +5,7 @@ LABEL maintainer="remi.ete@desy.de"
 LABEL description="Image to install iLCSoft on CVMFS for centos7 flavor"
 LABEL os="centos7"
 
-RUN yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm
-
-RUN yum install -y cvmfs \
+RUN yum install -y \
     	 wget \
 		   emacs \
 		   sudo \
@@ -41,6 +39,8 @@ RUN yum install -y cvmfs \
 		   kernel-devel
 
 RUN yum groupinstall -y "Development Tools"
+
+RUN yum clean all && rm -rf /var/cache/yum
 
 # Start the image with BASH by default
 CMD ["/bin/bash"]


### PR DESCRIPTION
BEGINRELEASENOTES
- Update cvmfs installation docker container 

ENDRELEASENOTES

Removing the explicit installation of cvmfs inside the container, since we do not need it because we bind-mount the necessary repositories. Having cvmfs installed inside the image can lead to problems when starting the image, depending on how singularity is configured:
```
FATAL:   container creation failed: mount /proc/self/fd/10->/var/singularity/mnt/session/rootfs error: while mounting image /proc/self/fd/10: failed to mount squashfs filesystem: input/output error
```

Also cleaning up after installing to reduce the size of the image.
