### PR TITLE
Py3 tagger

### DIFF
--- a/scripts/ilcsofttagger.py
+++ b/scripts/ilcsofttagger.py
@@ -7,6 +7,7 @@ Tagging System for iLCSoft libraries. Make tags, collate release notes via comma
 owner, repository, branch, tag (optional), createReleaseNotes(bool), prerelease(bool)
 
 """
+from __future__ import print_function
 
 from logging import getLogger
 import logging
@@ -105,9 +106,9 @@ class ILCSoftTagger(object):
     for package in self.repos:
       versionsContent += '\n%s_version = "%s" ' % ( package.repo, package.newTag )
 
-    print "*"*80
-    print versionsContent
-    print "*"*80
+    print("*"*80)
+    print(versionsContent)
+    print("*"*80)
 
 
   def _parseConfigFile( self ):

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -267,11 +267,10 @@ class Repo(object):
     return
 
   def getAuthorForPR( self, pr ):
-    """ return the author name of given PR, check cache if username already known """
-    username = pr['user']['login']
+    """Return the author name of given PR."""
     prID = pr['number']
     url=self._github("pulls/%s/commits" % prID)
-    authorName = authorMapping(username, url)
+    authorName = authorMapping(url)
     return authorName
     
     

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -329,8 +329,8 @@ class Repo(object):
 
     releaseNotesString = "# " + self.newVersion.split("-pre")[0] ## never write comments for new releases
 
-    for date, prs in sorted(self._releaseNotes.iteritems(), reverse=True):
-      for prID, content in sorted(prs.iteritems(), reverse=True):
+    for date, prs in sorted(self._releaseNotes.items(), reverse=True):
+      for prID, content in sorted(prs.items(), reverse=True):
         if not content.get( 'notes' ):
           continue
 

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -325,7 +325,7 @@ class Repo(object):
       self._getReleaseNotes()
 
     if self.isUpToDate():
-      return
+      return ''
 
     releaseNotesString = "# " + self.newVersion.split("-pre")[0] ## never write comments for new releases
 

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -3,6 +3,7 @@ interface to github via CURL
 
 """
 
+import base64
 import json
 from logging import getLogger
 from collections import OrderedDict, defaultdict
@@ -358,7 +359,7 @@ class Repo(object):
       content = "\n".join(content.split("\n")[2:]) ## remove first line which is the release name
     contentNew = self.formatReleaseNotes() + "\n\n" + content
     
-    contentEncoded = contentNew.encode('base64')
+    contentEncoded = base64.b64encode(contentNew.encode()).decode()
 
     if encodedOld.replace("\n","") == contentEncoded.replace("\n",""):
       self.log.info("No changes in %s, not making commit", self.releaseNotesFilename )
@@ -369,13 +370,12 @@ class Repo(object):
 
   def getFileFromBranch( self, filename ):
     """return the content of the file in the given branch, filename needs to be the full path"""
-
     result = curl2Json(url=self._github( "contents/%s?ref=%s" %(filename,self.branch)))
     encoded = result.get( 'content', None )
     if encoded is None:
       self.log.error( "File %s not found for %s", filename, self )
       raise RuntimeError( "File not found" )
-    content = encoded.decode("base64")
+    content = base64.b64decode(encoded).decode()
     sha = result['sha']
     return content, sha, encoded
 
@@ -390,7 +390,7 @@ class Repo(object):
     content = pMajor.sub( "_VERSION_MAJOR %s" % major, content )
     content = pMinor.sub( "_VERSION_MINOR %s" % minor, content )
     content = pPatch.sub( "_VERSION_PATCH %s" % patch, content )
-    contentEncoded = content.encode('base64')
+    contentEncoded = base64.b64encode(content.encode()).decode()
     if encodedOld.replace("\n","") == contentEncoded.replace("\n",""):
       self.log.info("No changes in %s, not making commit", self.cmakeBaseFile )
     else:

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -266,20 +266,6 @@ class Repo(object):
       self.log.info( "... PRs merged after Tag: %s", ", ".join( sorted(str( pr['number'] ) for pr in self._prsSinceLastTag )) )
     return
 
-  def getCommentsForPR( self, prID ):
-    """get the comments for a PR
-
-    :param int prID: pull request ID to get the comments from
-    :returns: list of comments
-    """
-    self.log.debug( "Getting comments for PR %s", prID )
-    comments = curl2Json(url=self._github("issues/%s/comments" % prID))
-    commentTexts = []
-    for comment in comments:
-      commentTexts.append( comment['body'] )
-
-    return commentTexts
-
   def getAuthorForPR( self, pr ):
     """ return the author name of given PR, check cache if username already known """
     username = pr['user']['login']
@@ -310,11 +296,6 @@ class Repo(object):
       notes = parseForReleaseNotes( pr['body'] )
       if notes:
         relNotes[date][prID]['notes'].extend( notes )
-      commentTexts = self.getCommentsForPR( prID )
-      for comment in commentTexts:
-        notes = parseForReleaseNotes( comment )
-        if notes:
-          relNotes[date][prID]['notes'].extend( notes )
     self._releaseNotes = relNotes
     self.log.info( "... finished getting release notes" )
     return

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -12,10 +12,10 @@ import re
 from pprint import pprint
 from operator import itemgetter
 
-from helperfunctions import parseForReleaseNotes, curl2Json, \
-                            authorMapping, versionComp, versionToKey
+from tagging.helperfunctions import (parseForReleaseNotes, curl2Json,
+                                     authorMapping, versionComp, versionToKey)
 
-from parseversion import Version
+from tagging.parseversion import Version
 
 __RCSID__ = None
 

--- a/scripts/tagging/gitinterface.py
+++ b/scripts/tagging/gitinterface.py
@@ -12,7 +12,7 @@ from pprint import pprint
 from operator import itemgetter
 
 from helperfunctions import parseForReleaseNotes, curl2Json, \
-                            authorMapping, versionComp
+                            authorMapping, versionComp, versionToKey
 
 from parseversion import Version
 
@@ -112,7 +112,7 @@ class Repo(object):
       self.latestTagInfo['name'] = "00-00"
       self.latestTagInfo['pre'] = False
     else:
-      sortedTags = sorted(tags, key=itemgetter("name"), reverse=True, cmp=versionComp)
+      sortedTags = sorted(tags, reverse=True, key=versionToKey)
       if self._lastTag is None:
         di = sortedTags[0]
       else:

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -19,7 +19,7 @@ except ImportError:
                     """
                    )
 
-from parseversion import getVersionComp
+from tagging.parseversion import getVersionComp
 
 HAVE_REQUESTS=False
 try:

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -19,6 +19,8 @@ except ImportError:
                     """
                    )
 
+from parseversion import getVersionComp
+
 HAVE_REQUESTS=False
 try:
   import requests
@@ -79,6 +81,14 @@ def versionComp( v1, v2 ):
     return -1
   else:
     return 1
+
+def versionToKey(tag):
+  log = logging.getLogger('VersionComp')
+  v1 = tag['name']
+  log.debug('checking %s', v1)
+  result = getVersionComp(v1)
+  log.debug('Result %s', result)
+  return result
   
 
 def parseForReleaseNotes( commentBody ):

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -182,14 +182,12 @@ def _req2Json(url, parameterDict, requestType):
   return req.json()
 
 
-def authorMapping(username, url):
-  """return the name of the author for given username, query github
-  PR for author via the commands given
-  """
+def authorMapping(url):
+  """Return the name of the author for github PR forvia the commands given."""
   log = logging.getLogger("Author")
   log.debug("Checking Commits for Author")
   commits = curl2Json(url=url)
-  author = commits[-1]['commit']['author']['name'] ## use the last commit of PR to get author
+  author = commits[0]['commit']['author']['name'] # use the first commit of PR to get author
   log.debug( "Found author: %s", author )
   return author
 

--- a/scripts/tagging/helperfunctions.py
+++ b/scripts/tagging/helperfunctions.py
@@ -31,6 +31,9 @@ except ImportError:
   pass
 
 
+class MissingFileError(RuntimeError):
+  pass
+
 def versionComp( v1, v2 ):
   """ compare version strings, problem is comparing
   v1r8p0 to v02-07-00 e.g. in lcio otherwise we could use normal string comparison
@@ -169,6 +172,8 @@ def _req2Json(url, parameterDict, requestType):
   log = logging.getLogger("GitHub Requests")
   log.debug("Running %s with %s ", requestType, parameterDict)
   req = getattr(SESSION, requestType.lower())(url, json=parameterDict)
+  if req.status_code in (404,):
+    raise MissingFileError('File not found: %s' % url)
   if req.status_code not in (200, 201):
     log.error("Unable to access API: %s", req.text)
     raise RuntimeError("Failed to access API")

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -112,7 +112,7 @@ class Version( object ):
 
     if self.makePreRelease:
       versionString += "-pre"
-      if self.pre > 0:
+      if self.pre and self.pre > 0:
         versionString += "%d" % self.pre
 
     return versionString
@@ -121,3 +121,10 @@ class Version( object ):
     """ :returns: tuple of Major, Minor, Patch """
     patch = 0 if self.patch is None else self.patch
     return self.major, self.minor, patch
+
+
+def getVersionComp(version):
+  parsed = Version(version)
+  major, minor, patch = parsed.getMajorMinorPatch()
+  pre = parsed.pre if parsed.pre else 0
+  return 100 * 100 * 100 * major + 100 * 100 * minor + 100 * patch + pre

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -133,4 +133,4 @@ def getVersionComp(version):
     return (-1, -1, -1, -1)
   major, minor, patch = parsed.getMajorMinorPatch()
   pre = parsed.pre if parsed.pre else 0
-  return 100 * 100 * 100 * major + 100 * 100 * minor + 100 * patch + pre
+  return (major, minor, patch, pre)

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -15,6 +15,9 @@ class Version( object ):
 
   """
 
+  class VersionStringError(RuntimeError):
+    pass
+
   def __init__( self, versionString, makePreRelease=True ):
     self.version = versionString
     self.major = 0
@@ -43,7 +46,7 @@ class Version( object ):
       self.major = int(parts[0])
       self.minor = int(parts[1])
     else:
-      raise RuntimeError( "Cannot parse this version string: %s" % self.version )
+      raise self.VersionStringError("Cannot parse this version string: %s" % self.version)
 
     if len(parts) >= 3:
       if 'pre' == parts[2]:
@@ -59,7 +62,7 @@ class Version( object ):
       elif 'pre' in parts[3]:
         self.pre = int(parts[3].strip('pre'))
       else:
-        raise RuntimeError( "Cannot parse this version string: %s" % self.version )
+        raise self.VersionStringError("Cannot parse this version string: %s" % self.version)
 
 
   def __incrementPatch( self ):
@@ -124,7 +127,10 @@ class Version( object ):
 
 
 def getVersionComp(version):
-  parsed = Version(version)
+  try:
+    parsed = Version(version)
+  except Version.VersionStringError:
+    return (-1, -1, -1, -1)
   major, minor, patch = parsed.getMajorMinorPatch()
   pre = parsed.pre if parsed.pre else 0
   return 100 * 100 * 100 * major + 100 * 100 * minor + 100 * patch + pre

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -129,7 +129,8 @@ class Version( object ):
 def getVersionComp(version):
   try:
     parsed = Version(version)
-  except Version.VersionStringError:
+  except Version.VersionStringError as e:
+    getLogger('getVersionComp').debug(str(e))
     return (-1, -1, -1, -1)
   major, minor, patch = parsed.getMajorMinorPatch()
   pre = parsed.pre if parsed.pre else 0

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -420,9 +420,9 @@ class TestParseVersion( unittest.TestCase ):
 
   def test_sortVersions(self):
 
-    versions = ['v01-12', 'v00-10', 'v01-12-01', 'v02-22-00-pre3', 'v00-01']
+    versions = ['v01-12', 'v00-10', 'v02-02-00-bad', 'v01-12-01', 'v02-22-00-pre3', 'v00-01']
     sv = sorted(versions, key=getVersionComp)
-    assert sv == ['v00-01', 'v00-10', 'v01-12', 'v01-12-01', 'v02-22-00-pre3']
+    assert sv == ['v02-02-00-bad', 'v00-01', 'v00-10', 'v01-12', 'v01-12-01', 'v02-22-00-pre3']
     sv = sorted(versions, reverse=True, key=getVersionComp)
     assert sv == [
       'v02-22-00-pre3',
@@ -430,6 +430,7 @@ class TestParseVersion( unittest.TestCase ):
       'v01-12',
       'v00-10',
       'v00-01',
+      'v02-02-00-bad',
     ]
 
 

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -321,7 +321,7 @@ class TestHelpers( unittest.TestCase ):
   def test_getAuthor( self ):
     """ test the mapping of the username to authorname """
     with patch("tagging.helperfunctions.curl2Json",new=mockCurl):
-      retVal = authorMapping( 'username2', ['commands', 'pulls/12/commits'] )
+      retVal = authorMapping(['commands', 'pulls/12/commits'])
       self.assertEqual( retVal, 'User Name2' )
 
   def test_checkRate( self ):

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -1,9 +1,16 @@
 #!/bin/env python
 """Test the Tagging Modules"""
+from __future__ import print_function
+
 
 import json
 import logging
-import __builtin__
+try:
+  import __builtin__ as builtins
+  builtin_module_name = '__builtin__'
+except ImportError:  # for python3
+  import builtins
+  builtin_module_name = 'builtins'
 import unittest
 import os
 import shutil
@@ -23,8 +30,8 @@ from tagging.parseversion import Version
 
 __RCSID__ = "$Id$"
 
-REALIMPORT = __builtin__.__import__
-def myimport(name, globs, locs, fromlist):
+REALIMPORT = builtins.__import__
+def myimport(name, globs, locs, fromlist, level=0):
   """ raise error for import """
   if name=="GitTokens" and "GITHUBTOKEN" in fromlist:
     raise ImportError
@@ -274,13 +281,16 @@ class TestHelpers( unittest.TestCase ):
 
   def test_importError( self ):
     """ test the import error when not having githubtoken """
-    del sys.modules['tagging.helperfunctions']
-    del sys.modules['GitTokens']
+    try:
+      del sys.modules['tagging.helperfunctions']
+      del sys.modules['GitTokens']
+    except KeyError:
+      pass
 
-    with patch( "__builtin__.__import__", myimport ):
+    with patch(builtin_module_name + ".__import__", myimport):
       with self.assertRaises( ImportError ):
         from tagging.helperfunctions import GITHUBTOKEN
-        print GITHUBTOKEN
+        print(GITHUBTOKEN)
 
   def test_parseForReleaseNotes( self ):
     """ test parseForReleaseNotes """
@@ -299,7 +309,7 @@ class TestHelpers( unittest.TestCase ):
       value = curl2Json( ["some","repo", "command"] )
       args, kwargs = check.call_args
       self.assertEqual( value, "arg" )
-      print args, kwargs
+      print(args, kwargs)
       self.assertEqual( 'curl', args[0][0] )
       self.assertEqual( '-s', args[0][1] )
 
@@ -418,7 +428,7 @@ def runTests():
   suite.addTest( unittest.defaultTestLoader.loadTestsFromTestCase( TestHelpers ) )
 
   testResult = unittest.TextTestRunner( verbosity = 2 ).run( suite )
-  print testResult
+  print(testResult)
 
 if __name__ == '__main__':
   runTests()

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -26,7 +26,7 @@ sys.modules['requests'] = Mock(name="RequestMock",side_effect=ImportError("nope"
 
 from tagging.gitinterface import Repo
 from tagging.helperfunctions import getCommands, versionComp, parseForReleaseNotes, _curl2Json as curl2Json, authorMapping, checkRate
-from tagging.parseversion import Version
+from tagging.parseversion import Version, getVersionComp
 
 __RCSID__ = "$Id$"
 
@@ -418,6 +418,19 @@ class TestParseVersion( unittest.TestCase ):
     self.assertEqual( version.getMajorMinorPatch(), (1, 2, 0) )
 
 
+  def test_sortVersions(self):
+
+    versions = ['v01-12', 'v00-10', 'v01-12-01', 'v02-22-00-pre3', 'v00-01']
+    sv = sorted(versions, key=getVersionComp)
+    assert sv == ['v00-01', 'v00-10', 'v01-12', 'v01-12-01', 'v02-22-00-pre3']
+    sv = sorted(versions, reverse=True, key=getVersionComp)
+    assert sv == [
+      'v02-22-00-pre3',
+      'v01-12-01',
+      'v01-12',
+      'v00-10',
+      'v00-01',
+    ]
 
 
 


### PR DESCRIPTION
I think this works. cf. https://github.com/iLCSoft/CLICPerformance/releases/tag/v02-04-01

Related to #132 

BEGINRELEASENOTES
- ilcsofttagger: make python3 compatible, keep python2 compatibility for the moment
- ilcsofttagger: add --ignoreMissingCmake flag to ignore the absence of CMakeLists.txt in the repository
- ilcsofttagger: no longer look up release notes in comments to PRs, only the opening post
- ilcsofttagger: try to get author name from the first commit of a PR not the last, might fix issue with wrongly attributed changes in the release notes

ENDRELEASENOTES