### PR TITLE
Make version parsing work for ILDConfig tags

### DIFF
--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -57,7 +57,7 @@ class Version( object ):
       elif 'pre' in parts[2]:
         self.pre = int(parts[2].strip('pre'))
       else:
-        self.patch = int( parts[2] )
+        self.patch = int( parts[2].strip('p') )
 
     if len(parts) >= 4:
       if 'pre' == parts[3]:


### PR DESCRIPTION
A few tags in `ILDConfig` have an ever so slightly different format, using `p` instead of `pre`, which breaks the tagging script.

BEGINRELEASENOTES
- Make the tagging script no longer error for ILDConfig patch releases with a `pXY` patch version specifier. **NOTE: This only makes the tagging script ignore such tags**. It does not handle them on the same footing as other versions.

ENDRELEASENOTES