### PR TITLE
Preparations for a new developers release cycle v02-03

### DIFF
--- a/doc/release_notes_ilcsoft_v02-03.md
+++ b/doc/release_notes_ilcsoft_v02-03.md
@@ -1,0 +1,204 @@
+# iLCSoft v02-03
+
+Development release after the 250 GeV production.
+
+Main changes wrt. v02-02 production release:
+- **Upgrade from python2 to python3**, this might break some of your python scripts if you have not made them compatible with both versions.
+- Switch to gcc-10.3
+- All external packages are used in their latest released version
+
+The files produced with the v02-02 series can still be read and used with this developers release, but they are potentially not fully compatible with files that are produced with the new developers release. There have been some changes in the reconstruction that break full (physics) backwards compatibility, see below for more details.
+
+## External software versions upgrade
+- gcc: 8.2.0 :arrow_right: 10.3.0
+- python: 2.7.16 :arrow_right: 3.8.6
+- ROOT: 6.18/04 :arrow_right: 6.26/06
+- Boost: 1.71.0 :arrow_right: 1.77.0
+- Eigen: 3.3.7 :arrow_right: 3.4.0
+- XercesC: 3.2.2 :arrow_right: 3.2.3
+- Geant4: 10.04.p03 :arrow_right: 11.0.2
+- GSL: 2.6 :arrow_right: 2.7
+- CMake: 3.15.5 :arrow_right: 3.23.2
+- CLHEP: 2.3.4.3 :arrow_right: 2.4.5.3
+- MySQL: 5.0.45 :arrow_right: 10.4.20
+- DD4hep: v01-11-02 :arrow_right: v01-20-02
+
+## New packages
+
+### podio v00-14-03 (ilcsoft)
+* [AIDASoft/podio](https://github.com/AIDASoft/podio)
+
+### EDM4hep v00-05 (ilcsoft)
+* [key4hep/EDM4hep](https://github.com/key4hep/EDM4hep)
+
+## Packages changed wrt. v02-02-03
+
+### CED v01-09-04
+
+* 2022-03-18 Thomas Madlener ([PR#10](https://github.com/iLCSoft/CED/pull/10))
+  - Make sure to link against GLUT libraries
+
+* 2022-03-18 Thomas Madlener ([PR#9](https://github.com/iLCSoft/CED/pull/9))
+  - Migrate CI to github actions.
+
+### MarlinFastJet v00-05-03
+
+* 2022-06-29 Andre Sailer ([PR#21](https://github.com/iLCSoft/MarlinFastJet/pull/21))
+  - FastJetUtil: fix memory leak in clusterJets function. Change signature of this function to include the clusterSequence, fixes #20 
+  - FastJetProcessor: fix issue for kt algorithm ,fixes #15
+
+* 2021-12-03 Thomas Madlener ([PR#18](https://github.com/iLCSoft/MarlinFastJet/pull/18))
+  - Migrate CI to github actions.
+
+* 2021-12-03 Frank Gaede ([PR#17](https://github.com/iLCSoft/MarlinFastJet/pull/17))
+  - fix order of fastjet libraries at linking step - needed on Ubuntu systems
+  -  fixes https://github.com/iLCSoft/iLCInstall/issues/128
+
+* 2021-12-03 Frank Gaede ([PR#16](https://github.com/iLCSoft/MarlinFastJet/pull/16))
+  - minor fix of source paths in cmake file (for newer cmake versions, eg. 3.17)
+
+### MarlinReco v01-33
+
+* 2022-04-19 Bohdan Dudar ([PR#104](https://github.com/iLCSoft/MarlinReco/pull/104))
+  - Migrated track length and  mean harmonic momentum code from `TOFEstimators` into separate `TrackLengthProcessor` to save CPU computing time. 
+  - **NOTE: If you have been using these processors outside of the standard reconstruction chain you will have to update your steering files** (see [iLCSoft/ILDConfig#133](https://github.com/iLCSoft/ILDConfig/pull/133) for the necessary changes)
+  
+### lcgeo v00-16-08
+
+* 2022-06-14 Valentin Volkl ([PR#253](https://github.com/iLCSoft/lcgeo/pull/253))
+  - Move SiD_o2_v04 beampipe constants to global list to fix an error in key4hep builds
+
+* 2022-06-09 Dan Protopopescu ([PR#252](https://github.com/iLCSoft/lcgeo/pull/252))
+  - Added SiD_o2_v04, which is an updated version of o2_v03, containing a few fixes, among which
+      - correct size and position of ECal layer 0 via new driver ECalBarrel_o2_v04_geo.cpp
+      - new beam pipe by Chris Potter
+      - removed brass HCal option
+
+* 2022-03-19 Valentin Volkl ([PR#251](https://github.com/iLCSoft/lcgeo/pull/251))
+  - Fix more hyphens in xml comments
+
+* 2022-03-09 Andre Sailer ([PR#249](https://github.com/iLCSoft/lcgeo/pull/249))
+  - Rebrand LCGEO as Lepton Collider GEOmetry, Fix #248
+ 
+### CEDViewer v01-19-01
+
+* 2022-06-22 Thomas Madlener ([PR#23](https://github.com/iLCSoft/CEDViewer/pull/23))
+  - Make sure that `ced2go` can be run without the `-n` argument even if `CED_HOST` is set. Fixes #21
+  - Remove some compatibility code for python < 2.4
+
+* 2022-03-11 Bohdan Dudar ([PR#20](https://github.com/iLCSoft/CEDViewer/pull/20))
+  - Fix typo bug in the ced2go local host argument option
+
+### KalTest v02-05-01
+
+* 2022-06-27 Daniel Jeans ([PR#5](https://github.com/iLCSoft/KalTest/pull/5))
+  - add missing factor 0.5 to density term of Bethe-Bloch parameterisation
+
+* 2020-04-12 Frank Gaede ([PR#4](https://github.com/iLCSoft/KalTest/pull/4))
+  - fix issue w/ c++17 
+        - this caused KalTest to return a “filtered” state as its “smoothed” or “inverse-filtered” state
+        - patch provided by K.Fujii
+        
+### DDKalTest v01-07
+
+* 2022-06-24 Daniel Jeans ([PR#13](https://github.com/iLCSoft/DDKalTest/pull/13))
+  - - add missing factor 0.5 to density term of Bethe-Bloch parameterisation
+
+* 2022-06-17 Thomas Madlener ([PR#14](https://github.com/iLCSoft/DDKalTest/pull/14))
+  - Make CI use github actions instead of travis-CI
+
+### LCIO v02-17-01
+
+* 2022-05-09 Thomas Madlener ([PR#146](https://github.com/iLCSoft/LCIO/pull/146))
+  - Install all the necessary headers to make the python bindings work, even if the sources are removed after installation. Fixes #106
+  
+### MarlinKinfitProcessors v00-05
+
+* 2022-06-28 Thomas Madlener ([PR#18](https://github.com/iLCSoft/MarlinKinfitProcessors/pull/18))
+  - Make doxygen cmake config work with newer cmakes (>= 3.17)
+
+* 2022-05-17 JennyListDESY ([PR#17](https://github.com/iLCSoft/MarlinKinfitProcessors/pull/17))
+  - bug fix in ZHllqq5CFit for usage of fixed JER
+
+* 2022-04-20 Jenny List ([PR#16](https://github.com/iLCSoft/MarlinKinfitProcessors/pull/16))
+  - preparations towards a MarlinKinfit tutorial:
+      - fixing CMakeLists.txt to include MarlinUtil
+      - adding an ee->ZH->llqq example with up-to-date ErrorFlow, based on work from Yasser Radkhorrami and Julie Torndal
+  - example steering still assumes availability of two private processors, which are yet to be made available in a next step.
+
+* 2022-04-04 Thomas Madlener ([PR#15](https://github.com/iLCSoft/MarlinKinfitProcessors/pull/15))
+  - Migrate CI to github actions and remove travis CI setup
+
+### LCCD v01-05-01
+
+* 2022-06-28 Thomas Madlener ([PR#5](https://github.com/iLCSoft/LCCD/pull/5))
+  - Fix bug in coverity config to point to the right repo
+
+* 2022-06-28 Thomas Madlener ([PR#4](https://github.com/iLCSoft/LCCD/pull/4))
+  - Migrate CI to github actions and remove travis CI configuration
+
+* 2022-06-28 Thomas Madlener ([PR#3](https://github.com/iLCSoft/LCCD/pull/3))
+  - Replace the implicit globbing for the doxygen target with an explicit cmake glob expression in order for working documentation generation with cmake >= 3.17
+
+* 2020-04-10 Frank Gaede ([PR#2](https://github.com/iLCSoft/LCCD/pull/2))
+  - make compatible w/ c++17 for macos/clang
+        - patch provided by K.Fujii
+
+### GEAR v01-09-01
+
+* 2022-06-28 Thomas Madlener ([PR#8](https://github.com/iLCSoft/GEAR/pull/8))
+  - Fix cmake doxygen configuration to work with CMake >= 3.17
+
+* 2022-06-28 Thomas Madlener ([PR#7](https://github.com/iLCSoft/GEAR/pull/7))
+  - Migrate CI to use github actions and remove travis CI
+
+* 2020-09-07 Valentin Volkl ([PR#6](https://github.com/iLCSoft/GEAR/pull/6))
+  - put more tests under the scope of BUILD_TESTING. Also fixes a build issue with spack https://github.com/key4hep/k4-spack/pull/33
+ 
+  
+### LCTuple v01-14
+
+* 2022-06-29 Kollassery Swathi Sasikumar ([PR#10](https://github.com/iLCSoft/LCTuple/pull/10))
+  - Changed the names of parameter in the event header to the names that are used in MC2020
+
+* 2022-06-28 Thomas Madlener ([PR#13](https://github.com/iLCSoft/LCTuple/pull/13))
+  - Make doxygen cmake config work with newer cmake versions (>= 3.17)
+
+### Physsim v00-04-02
+
+* 2021-08-16 Valentin Volkl ([PR#1](https://github.com/iLCSoft/Physsim/pull/1))
+  - Add explicit include for TString.h to avoid build failure with ROOT v6.24
+  
+### ILDConfig v02-03
+
+* 2022-06-29 Gerald Grenier ([PR#131](https://github.com/iLCSoft/ILDConfig/pull/131))
+  - Add Calibration files to be able to run standard Marlin reconstruction on ILD simulation with Videau geometry.
+  - For this first pass, files are only link to current ILD option 2 model from hybrid TESLA geometry.
+  - Verification that Marlin runs on both small and large ILD Videau geometry have been done.
+
+* 2022-04-20 Bohdan Dudar ([PR#133](https://github.com/iLCSoft/ILDConfig/pull/133))
+  - Added TrackLength processor in the HighLevelReco chain.
+
+* 2022-03-14 Bohdan Dudar ([PR#132](https://github.com/iLCSoft/ILDConfig/pull/132))
+  - All steering parameters of `TOFEstimators` are explicitly specified in the steering file w/o any modification to the behaviour
+
+
+## CMake fixes and CI migrations
+The following packages have received a bump in their version numbers due to same fix in the cmake configuration that has been applied to all of them. The fix was necessary to make the doxygen generation work with the newer CMake versions (>= 3.17). Additionally, some of these packages were not yet migrated to the github actions CI, which has also been done for these packages. Instead of repeating the same release notes over and over again, here we simply provide the links to the corresponding pull requests
+
+* MarlinDD4hep v00-06-01
+  - [PR#8](https://github.com/iLCSoft/MarlinDD4hep/pull/8) 
+* MarlinUtil v01-16-02
+  - [PR#27](https://github.com/iLCSoft/MarlinUtil/pull/27)
+* MarlinTrk v02-09-01
+  - [PR#24](https://github.com/iLCSoft/MarlinTrk/pull/24)
+* MarlinTrkProcessors v02-12-02
+  - [PR#61](https://github.com/iLCSoft/MarlinTrkProcessors/pull/61)
+* MarlinKinfit v00-06-01
+  - [PR#2](https://github.com/iLCSoft/MarlinKinfit/pull/2)
+* Overlay v00-22-04
+  - [PR#25](https://github.com/iLCSoft/Overlay/pull/25)
+* KiTrackMarlin v01-13-01
+  - [PR#6](https://github.com/iLCSoft/KiTrackMarlin/pull/6)
+* ForwardTracing v01-14-01
+  - [PR#14](https://github.com/iLCSoft/ForwardTracking/pull/14)

--- a/ilcsoft-install
+++ b/ilcsoft-install
@@ -72,6 +72,7 @@ ilcsoft_afs_path['gcc82_64bit_centos7'] = os.path.normpath( os.path.join( ilcsof
 ilcsoft_afs_path['gcc46_64bit'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc46_ub1204' ))
 ilcsoft_afs_path['gcc75_64bit_ub1804'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc75_ub1804' ))
 ilcsoft_afs_path['gcc93_64bit_ub2004'] = os.path.normpath( os.path.join( ilcsoft_afs_path['base'] , 'x86_64_gcc93_ub2004' ))
+ilcsoft_afs_path['gcc10_64bit_centos7'] = os.path.normpath(os.path.join(ilcsoft_afs_path['base'], 'x86_64_gcc103_centos7'))
 
 ilcPath = None
 installPrefix = None

--- a/releases/v02-03/release-base.cfg
+++ b/releases/v02-03/release-base.cfg
@@ -1,0 +1,159 @@
+##############################################################################
+#
+# Configuration file for installing base-level tools of ILC Software v01-14
+#
+# This cfg file is part 1 of a 2 step installation procedure:
+#
+# Part 1 installs the so called "base-level" tools of the ilcsoft release
+# (base-level tools are the tools which do not have dependencies and can
+# therefore be 're-linked' from release to release
+#
+# base-level tools are typically installed to:
+# /afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5/ # 64bit
+# /afs/desy.de/project/ilcsoft/sw/i386_gcc41_sl5/   # 32bit
+#
+# Part 2 is done with cfg file release_v01-09.cfg and installs the
+# remaining software which has dependencies and therefore needs to
+# be re-installed from release to release. Part 2 installation links
+# to the packages installed with Part 1
+#
+# ilcsoft releases are typically installed to:
+# /afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5/v01-14 # 64bit
+# /afs/desy.de/project/ilcsoft/sw/i386_gcc41_sl5/v01-14   # 32bit
+#
+# Please do not forget to modify the directories in this cfg file
+# according to your system !!
+#
+# Alternatively to the 2 step installation procedure you may choose to
+# use the release_v01-14-scratch.cfg configuration file which installs
+# all software in one single step. The only disadvantage is that future
+# installations of new releases have to go into the same directory of the
+# previous installation for being able to re-use the base-level tools of the
+# old installation (or require significant changes in the configuration file)
+#
+# Author: F. Gaede, J. Engels, DESY
+# Date: Jun 30, 2010
+#
+##############################################################################
+
+import os, sys
+
+# read package versions from external file
+path_where_this_file_lives = os.path.dirname( config_file )
+versions_file = os.path.join( path_where_this_file_lives, "release-versions.py" )
+exec(compile(open(versions_file, "rb").read(), versions_file, "exec"))
+
+# installation directory
+if not 'ilcsoft_install_dir' in dir():
+    if not 'ilcsoft_install_prefix' in dir():
+        # default install prefix
+        ilcsoft_install_prefix = "$HOME/ilcsoft"
+
+    ilcsoft_install_dir = ilcsoft_install_prefix
+    #ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
+
+ilcsoft = ILCSoft( ilcsoft_install_dir )
+
+
+# global options
+if not ncores:
+   ncores = 4
+
+ilcsoft.env["MAKEOPTS"]="-j" + str(ncores)
+ilcsoft.env["CXX"]="g++"
+ilcsoft.env["CC"]="gcc"
+
+if( ilcsoft.os.isSL(4) ):
+    ilcsoft.env["FC"]="g77"
+
+#
+#ilcsoft.envcmake['CMAKE_CXX_FLAGS']= CMAKE_CXX_FLAGS
+ilcsoft.envcmake['USE_CXX11']=False
+ilcsoft.envcmake['CMAKE_CXX_STANDARD']=cxx_standard
+#
+
+# ----- build and install documentation -------------
+ilcsoft.envcmake["INSTALL_DOC"]="ON"
+
+
+ilcsoft.envcmake["CMAKE_BUILD_TYPE"]= "RelWithDebInfo"
+ilcsoft.downloadType = "svn"
+
+# additional system pathes for FIND_LIBRARY, FIND_PATH
+#-----------------------------------------------
+#ilcsoft.env["CMAKE_LIBRARY_PATH"]="/usr/lib/gcc/i386-redhat-linux/3.4.3:/another/path/lib"
+#ilcsoft.env["CMAKE_INCLUDE_PATH"]="/usr/include/c++/3.4.3:/another/path/include"
+#-----------------------------------------------
+
+###########################################################
+
+
+
+# ------ packages with no install support -------------
+# need to be pre-installed on your system
+if 'MySQL_path' in dir():
+    ilcsoft.use( MySQL( MySQL_path ))
+# -----------------------------------------------------
+
+ilcsoft.install( ILCUTIL( ILCUTIL_version ))
+
+ilcsoft.install( CondDBMySQL( CondDBMySQL_version ))
+
+ilcsoft.install( CED( CED_version ))
+# ---- optionally build the CED event display
+# ---- requires GLUT and OpenGL installed on your system
+ilcsoft.module("CED").envcmake['CED_SERVER']='ON'
+
+ilcsoft.install( FastJet( FastJet_version ))
+ilcsoft.module("FastJet").fjcontrib_version=FastJetcontrib_version
+ilcsoft.module("FastJet").env["CXXFLAGS"]='-std=c++' + str(cxx_standard)
+
+# -- xercesc
+ilcsoft.install( XercesC( XercesC_version ))
+
+ilcsoft.install( Geant4( Geant4_version ))
+geant4=ilcsoft.module("Geant4")
+geant4.envcmake["GEANT4_INSTALL_DATA"]='ON'
+geant4.envcmake["GEANT4_USE_SYSTEM_EXPAT"]='OFF' # ignored ??
+geant4.envcmake["GEANT4_USE_SYSTEM_CLHEP"]='ON'
+geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
+geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
+geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
+#geant4.envcmake["GEANT4_BUILD_CXXSTD"]='c++' + str(cxx_standard)
+geant4.envcmake["GEANT4_BUILD_CXXSTD"]=str(cxx_standard)
+geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='7200'
+
+#geant4.envcmake["QT_QMAKE_EXECUTABLE"]=/path/to/qmake
+if 'XERCESC_ROOT_DIR' in dir():
+    geant4.envcmake["XERCESC_ROOT_DIR"]=XERCESC_ROOT_DIR
+    geant4.envcmake["GEANT4_USE_GDML"]='ON' # requires xerces-c
+
+ilcsoft.install( ROOT( ROOT_version ))
+ilcsoft.module("ROOT").download.type="wget"
+ilcsoft.module("ROOT").envcmake['root7']="ON"
+ilcsoft.module("ROOT").envcmake['webgui']="ON"
+
+ilcsoft.install( CLHEP( CLHEP_version ))
+ilcsoft.install( GSL( GSL_version ))
+ilcsoft.module("GSL").use_c11=True
+ilcsoft.install( Qt5( Qt5_version ))
+
+# cmake
+ilcsoft.install( CMake( CMake_version ))
+
+# sio package
+ilcsoft.install( SIO( SIO_version ))
+sio=ilcsoft.module("SIO")
+sio.envcmake["SIO_BUILTIN_ZLIB"]='OFF'
+sio.envcmake["SIO_EXAMPLES"]='OFF'
+sio.envcmake["SIO_MACROS_WITH_EXCEPTION"]='OFF'
+sio.envcmake["SIO_RELEASE_OFAST"]='OFF'
+
+# boost
+ilcsoft.install( Boost( Boost_version ) )
+ilcsoft.module("Boost").buildopts["cxxstd"]=cxx_standard
+
+# eigen3
+ilcsoft.install( Eigen( Eigen_version ) )
+
+# end of configuration file

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -1,0 +1,344 @@
+#############################################################################
+#
+# Configuration file for installing ILC Software release v01-14
+#
+# This cfg file assumes the base-level tools from release_v01-14-base.cfg
+# are already installed and available in your system (base-level tools are the
+# tools which are set as 'ilcsoft.link' at the end of this file
+#
+# If you do not have this tools available on your system you can install them
+# with the configuration file release_v01-14-base.cfg or alternatively
+# install all software with release_v01-14-scratch.cfg (please check
+# release_v01-14-base.cfg for more details)
+#
+# Please do not forget to modify the directories in this cfg file
+# according to your system !!
+#
+# Author: F. Gaede, J. Engels, DESY
+# Date: Jun 30, 2010
+#
+##############################################################################
+
+import os, sys
+
+# read package versions from external file
+path_where_this_file_lives = os.path.dirname( config_file )
+versions_file = os.path.join( path_where_this_file_lives, "release-versions.py" )
+exec(compile(open(versions_file, "rb").read(), versions_file, "exec"))
+
+print("Do we install nightlies? ", nightlies)
+
+# installation directory
+if not 'ilcsoft_install_dir' in dir():
+    if not 'ilcsoft_install_prefix' in dir():
+        # default install prefix
+        ilcsoft_install_prefix = "$HOME/ilcsoft"
+
+ilcsoft_install_dir = os.path.join( ilcsoft_install_prefix, ilcsoft_release )
+ilcsoft = ILCSoft( ilcsoft_install_dir )
+
+# configuration for nightlies
+if (nightlies==True):
+    ilcsoft_install_dir = ilcsoft = ILCSoft("/scratch/nbuilds/"+date_iso8601)
+    ilcsoft.nightlyBuild=True
+    ilcsoft.nightlyTargets=['NightlyStart', 'NightlyConfigure', 'NightlyBuild', 'install', 'NightlyTest', 'NightlySubmit']
+
+
+# python variable for referring the ILC Home directory
+# used to link or use already installed packages (SL5)
+# --- set in release-versions.py ---
+#ilcPath = "/afs/desy.de/group/it/ilcsoft/"
+#ilcPath = '/afs/desy.de/project/ilcsoft/sw/i386_gcc41_sl5/'
+if not 'ilcPath' in dir():
+    raise "ilcPath not set"
+
+ilcPath = os.path.normpath( ilcPath ) + '/' # make sure there it ends with /
+
+# global options
+if not ncores:
+   ncores = 4
+
+ilcsoft.env["MAKEOPTS"]="-j" + str(ncores)
+ilcsoft.env["CXX"]="g++"
+ilcsoft.env["CC"]="gcc"
+#
+# Set it to false as ilcutil by default set it to ON.
+# In this case USE_CXX11 overrides the CMAKE_CXX_STANDARD
+ilcsoft.envcmake['USE_CXX11']=False
+ilcsoft.envcmake['CMAKE_CXX_STANDARD']=cxx_standard
+ilcsoft.envcmake["Boost_NO_BOOST_CMAKE"] = 'ON'
+#
+
+# ----- build and install documentation -------------
+ilcsoft.envcmake["INSTALL_DOC"]="OFF"
+
+
+# ilcsoft.envcmake["CMAKE_BUILD_TYPE"]= "Debug"
+ilcsoft.envcmake["CMAKE_BUILD_TYPE"]= "RelWithDebInfo"
+ilcsoft.downloadType = "GitHub"
+#ilcsoft.downloadType = "svn-desy"
+
+# additional system pathes for FIND_LIBRARY, FIND_PATH
+#-----------------------------------------------
+#ilcsoft.env["CMAKE_LIBRARY_PATH"]="/usr/lib/gcc/i386-redhat-linux/3.4.3:/another/path/lib"
+#ilcsoft.env["CMAKE_INCLUDE_PATH"]="/usr/include/c++/3.4.3:/another/path/include"
+#-----------------------------------------------
+
+
+###########################################################
+
+ilcsoft.install( LCCD( LCCD_version ))
+
+ilcsoft.install( Marlin( Marlin_version ))
+ilcsoft.module("Marlin").envcmake["MARLIN_GUI"]='OFF'
+
+ilcsoft.install( MarlinPKG( "MarlinDD4hep", MarlinDD4hep_version ))
+ilcsoft.module("MarlinDD4hep").addDependency( [ 'Marlin', 'DD4hep', 'Root', 'DDKalTest'] )
+
+ilcsoft.install( MarlinPKG( "DDMarlinPandora", DDMarlinPandora_version ))
+ilcsoft.module("DDMarlinPandora").addDependency( [ 'Marlin', 'MarlinUtil', 'DD4hep', 'ROOT', 'PandoraPFANew', 'MarlinTrk'] )
+ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
+
+
+ilcsoft.install( MarlinUtil( MarlinUtil_version ))
+
+
+#----------  standard reco packages
+
+ilcsoft.install( MarlinReco( MarlinReco_version )) 
+ilcsoft.module("MarlinReco").envcmake["MARLINRECO_FORTRAN"]='OFF'  
+
+ilcsoft.install( PandoraAnalysis( PandoraAnalysis_version ))
+# Until https://github.com/PandoraPFA/LCPandoraAnalysis/pull/17 is merged
+ilcsoft.module("PandoraAnalysis").envcmake["INSTALL_DOC"] = "OFF"
+
+ilcsoft.install( PandoraPFANew( PandoraPFANew_version ))
+
+ilcsoft.module("PandoraPFANew").envcmake["PANDORA_MONITORING"]='ON'
+ilcsoft.module("PandoraPFANew").envcmake["LC_PANDORA_CONTENT"]='ON'
+ilcsoft.module("PandoraPFANew").envcmake["EXAMPLE_PANDORA_CONTENT"]='ON'
+ilcsoft.module("PandoraPFANew").envcmake["CMAKE_PREFIX_PATH"]='${ROOTSYS}/cmake'
+ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-std=c++%s' % cxx_standard
+
+
+ilcsoft.install( LCFIVertex( LCFIVertex_version ))
+ilcsoft.module("LCFIVertex").envcmake["INSTALL_DOC"]="OFF"
+# ilcsoft.module( "LCFIVertex" ).envcmake["BOOST_ROOT"] = Boost_path
+
+ilcsoft.install( CEDViewer( CEDViewer_version )) 
+
+ilcsoft.install( Overlay( Overlay_version ))  
+
+ilcsoft.install( MarlinPKG( "MarlinFastJet", MarlinFastJet_version ))
+ilcsoft.module("MarlinFastJet").addDependency( [ 'LCIO', 'Marlin', 'FastJet'] )
+
+ilcsoft.install( MarlinPKG( "LCTuple", LCTuple_version ))
+ilcsoft.module("LCTuple").addDependency( [ 'LCIO', 'Marlin', 'ROOT'] )
+
+ilcsoft.install( MarlinPKG( "MarlinKinfit", MarlinKinfit_version ))
+ilcsoft.module("MarlinKinfit").hasCMakeFindSupport=True
+ilcsoft.module("MarlinKinfit").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin'] )
+
+ilcsoft.install( MarlinTrk( MarlinTrk_version ))
+ilcsoft.install( KiTrack( KiTrack_version ))
+ilcsoft.install( KiTrackMarlin( KiTrackMarlin_version ))
+
+ilcsoft.install( MarlinPKG( "MarlinTrkProcessors", MarlinTrkProcessors_version ))
+ilcsoft.module("MarlinTrkProcessors").addDependency( [ 'LCIO', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'KalTest', 'KalDet', 'MarlinTrk', 'KiTrack', 'KiTrackMarlin'] )
+
+ilcsoft.install( MarlinPKG( "MarlinKinfitProcessors", MarlinKinfitProcessors_version ))
+ilcsoft.module("MarlinKinfitProcessors").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin'] )
+
+ilcsoft.install( MarlinPKG( "ILDPerformance", ILDPerformance_version ))
+ilcsoft.module("ILDPerformance").addDependency( [ 'Marlin', 'MarlinUtil', 'ROOT'] )
+
+#-- for convenience also include the HEAD version of ILDconfig
+ilcsoft.install( ConfigPKG( "ILDConfig", ILDConfig_version ))
+ilcsoft.module("ILDConfig").addDependency( [ 'Marlin', 'MarlinUtil', 'ROOT'] )
+
+ilcsoft.install( MarlinPKG( "Clupatra", Clupatra_version ))
+# Clupatra generates a clupatraConfig.cmake file
+ilcsoft.module("Clupatra").hasCMakeFindSupport=True
+ilcsoft.module("Clupatra").addDependency( [ 'LCIO', 'ROOT', 'RAIDA', 'Marlin', 'MarlinUtil', 'KalTest', 'MarlinTrk' ] )
+
+ilcsoft.install( MarlinPKG( "Physsim", Physsim_version ))
+ilcsoft.module("Physsim").addDependency( [ 'LCIO', 'ROOT', 'Marlin' ] )
+
+ilcsoft.install( MarlinPKG( "FCalClusterer", FCalClusterer_version ))
+# Special case: BeamCalRecoConfig.cmake is generated in FCalClusterer
+ilcsoft.module("FCalClusterer").hasCMakeFindSupport=True
+ilcsoft.module("FCalClusterer").download.type="GitHub"
+ilcsoft.module("FCalClusterer").download.gituser="FCALSW"
+ilcsoft.module("FCalClusterer").download.gitrepo="FCalClusterer"
+ilcsoft.module("FCalClusterer").addDependency( [ 'DD4hep', 'LCIO', 'ROOT', 'GSL', 'Marlin' ] )
+
+ilcsoft.install( MarlinPKG( "LCFIPlus", LCFIPlus_version ))
+ilcsoft.module("LCFIPlus").download.type="GitHub"
+ilcsoft.module("LCFIPlus").download.gituser="lcfiplus"
+ilcsoft.module("LCFIPlus").download.gitrepo="LCFIPlus"
+ilcsoft.module("LCFIPlus").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'Marlin', 'MarlinUtil', 'LCFIVertex'] )
+
+ilcsoft.install( MarlinPKG( "ForwardTracking", ForwardTracking_version ))
+ilcsoft.module("ForwardTracking").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'MarlinTrk'] )
+
+
+ilcsoft.install( MarlinPKG( "ConformalTracking", ConformalTracking_version ))
+ilcsoft.module("ConformalTracking").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinTrk'] )
+
+
+ilcsoft.install( MarlinPKG( "LICH", LICH_version ))
+ilcsoft.module("LICH").download.type="GitHub"
+ilcsoft.module("LICH").download.gituser="danerdaner"
+ilcsoft.module("LICH").download.gitrepo="LICH"
+ilcsoft.module("LICH").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinUtil' ] )
+
+
+#---------test beam packages 
+
+#ilcsoft.install( Eutelescope( Eutelescope_version ))
+#ilcsoft.module("Eutelescope").env['EUDAQ_VERSION']='trunk'
+#ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='trunk'
+
+
+ilcsoft.install( PathFinder( PathFinder_version ))
+ilcsoft.module("PathFinder").download.type="svn"
+
+ilcsoft.install( MarlinTPC( MarlinTPC_version ))
+ilcsoft.module("MarlinTPC").download.type="svn"
+ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
+
+
+ilcsoft.install( BBQ( BBQ_version ))
+ilcsoft.module("BBQ").download.type="svn"
+
+#fg: needs porting to ROOT6 (dictionary!)
+#ilcsoft.install( Druid( Druid_version ))
+
+ilcsoft.install( Garlic( Garlic_version ))
+
+
+
+ilcsoft.install( RAIDA( RAIDA_version ))
+
+ilcsoft.install( KalTest( KalTest_version ))
+ilcsoft.install( KalDet( KalDet_version ))
+
+ilcsoft.install( GBL ( GBL_version ) )
+
+ilcsoft.link( XercesC( ilcPath + "xercesc/" + XercesC_version ))
+
+
+# DD4hep
+ilcsoft.install( DD4hep( DD4hep_version )) 
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEANT4"]=1
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_LCIO"]=1
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_XERCESC"]=0
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_PYROOT"]=0
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]=1
+# ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
+
+
+
+ilcsoft.install( lcgeo( lcgeo_version )) 
+
+
+ilcsoft.install( podio( podio_version ))
+ilcsoft.module("podio").envcmake["ENABLE_SIO"] = 'ON'
+ilcsoft.module("podio").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
+
+ilcsoft.install( edm4hep( edm4hep_version ))
+ilcsoft.module("edm4hep").envcmake["BUILD_DDG4EDM4HEP"] = 'OFF'
+ilcsoft.module("edm4hep").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
+
+
+ilcsoft.install( aidaTT( aidaTT_version )) 
+ilcsoft.module("aidaTT").download.type="GitHub"
+ilcsoft.module("aidaTT").download.gituser="AIDASoft"
+ilcsoft.module("aidaTT").download.gitrepo="aidaTT"
+
+ilcsoft.install( DDKalTest( DDKalTest_version ))
+
+ilcsoft.install( DD4hepExamples ( DD4hepExamples_version ))
+
+####################################################################
+#
+# the following tools are installed in afs:
+#
+# - for SL5 (32bit) under:
+#
+#     /afs/desy.de/project/ilcsoft/sw/i386_gcc41_sl5/
+#
+# - for SL5 (64bit) under:
+#
+#     /afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5
+#
+# they can be linked from there or need to be installed on your system
+#
+####################################################################
+
+
+#----- configs ------------------------------------------------------
+#ilcsoft.link( ConfigPKG( "StandardConfig", ilcPath + "StandardConfig/" + StandardConfig_version ) )
+#stdconf = ilcsoft.module( "StandardConfig")
+#stdconf.env["STANDARDCONFIG"]=stdconf.installPath
+#
+#ilcsoft.link( ConfigPKG( "MokkaDBConfig", ilcPath + "MokkaDBConfig/" + MokkaDBConfig_version ) ) 
+#mokkadbconf = ilcsoft.module( "MokkaDBConfig")
+#mokkadbconf.download.root = "ilctools"
+#mokkadbconf.envorder=["MOKKADBCONFIG"]
+#mokkadbconf.env["MOKKADBCONFIG"]=mokkadbconf.installPath
+#mokkadbconf.env["MOKKA_DUMP_FILE"]="$MOKKADBCONFIG/mokka-dbdump.sql.tgz"
+#mokkadbconf.envpath["PATH"].append( "$MOKKADBCONFIG/scripts" )
+#
+#ilcsoft.link( ConfigPKG( "LCFI_MokkaBasedNets", ilcPath + "LCFI_MokkaBasedNets/" + LCFI_MokkaBasedNets_version ) )
+#lcfinets=ilcsoft.module( "LCFI_MokkaBasedNets" )
+#lcfinets.download.root = "tagnet"
+#lcfinets.env["LCFIMOKKABASEDNETS"]=lcfinets.installPath
+#--------------------------------------------------------------------
+
+ilcsoft.link( CED( ilcPath + "CED/" + CED_version ))
+
+#ilcsoft.link( LCIO( ilcPath + "lcio/" + LCIO_version ))
+ilcsoft.install( LCIO( LCIO_version ))
+
+#----- this will build the optional ROOT dictionary for LCIO -----
+#------ set to OFF  if you don't want it
+ilcsoft.module("LCIO").envcmake['BUILD_ROOTDICT']='ON'
+#ilcsoft.module("LCIO").envcmake['INSTALL_DOC']='OFF'
+#ilcsoft.module("LCIO").envcmake['ROOT_HOME']='${ROOTSYS}'
+#ilcsoft.module("LCIO").envcmake["BUILD_WITH_DCAP"]="ON"
+# it is recommended to use the LD_PRELOAD mechanism for opening lcio files in dCache
+#ilcsoft.link( dcap( ilcPath + "dcap/" + dcap_version ))
+
+#ilcsoft.link( GEAR( ilcPath + "gear/" + GEAR_version ))
+ilcsoft.install( GEAR( GEAR_version ))
+ilcsoft.module("GEAR").envcmake['GEAR_TGEO']='ON'
+
+
+ilcsoft.link( SIO( ilcPath + "sio/" + SIO_version ))
+ilcsoft.link( FastJet( ilcPath + "FastJet/" + FastJet_version ))
+
+ilcsoft.link( ROOT( ilcPath + "root/" + ROOT_version ))
+
+ilcsoft.link( CLHEP( ilcPath + "CLHEP/" + CLHEP_version ))
+ilcsoft.link( GSL( ilcPath + "gsl/" + GSL_version ))
+ilcsoft.link( Qt5( ilcPath + "Qt5/" + Qt5_version ))
+ilcsoft.link( Geant4( ilcPath + "geant4/" + Geant4_version ))
+
+ilcsoft.link( CondDBMySQL( ilcPath + "CondDBMySQL/" + CondDBMySQL_version ))
+
+# mysql
+if 'MySQL_path' in dir():
+    ilcsoft.use( MySQL( MySQL_path ))
+
+# cmake
+ilcsoft.use( CMake( ilcPath + "CMake/" + CMake_version ))
+
+ilcsoft.link( ILCUTIL( ilcPath + "ilcutil/" + ILCUTIL_version ))
+
+ilcsoft.link( Boost( ilcPath + "boost/" + Boost_version ))
+
+ilcsoft.link( Eigen( ilcPath + "eigen/" + Eigen_version ))
+
+# end of configuration file
+

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -147,7 +147,7 @@ ilcsoft.install( MarlinPKG( "MarlinTrkProcessors", MarlinTrkProcessors_version )
 ilcsoft.module("MarlinTrkProcessors").addDependency( [ 'LCIO', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'KalTest', 'KalDet', 'MarlinTrk', 'KiTrack', 'KiTrackMarlin'] )
 
 ilcsoft.install( MarlinPKG( "MarlinKinfitProcessors", MarlinKinfitProcessors_version ))
-ilcsoft.module("MarlinKinfitProcessors").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin'] )
+ilcsoft.module("MarlinKinfitProcessors").addDependency( [ 'LCIO', 'GEAR', 'GSL', 'Marlin', 'MarlinUtil', 'MarlinKinfit'] )
 
 ilcsoft.install( MarlinPKG( "ILDPerformance", ILDPerformance_version ))
 ilcsoft.module("ILDPerformance").addDependency( [ 'Marlin', 'MarlinUtil', 'ROOT'] )

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -1,0 +1,243 @@
+###########################################
+#
+# iLCSoft versions for installing the v02-03 series of developer releases
+# version of the ilcsoft packages.
+# The external base tools need to be installed
+#
+# DESY ilcsoft team
+###########################################
+
+# --------- ilcsoft release version ------------------------------------------
+ilcsoft_release = 'v02-03'
+# ----------------------------------------------------------------------------
+
+# which cxx standard to use
+cxx_standard = 17
+
+#===============================================================================
+# use a compiler that knows c++17, use e.g. scripts/use_gcc103_cvmfs_centos7.sh
+#
+'''
+# --- gcc from LCG_101
+source /cvmfs/sft.cern.ch/lcg/releases/gcc/10.3.0/x86_64-centos7/setup.sh
+
+# --- python from LCG_101
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc10-opt/bin:${PATH}
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc10-opt/lib:${LD_LIBRARY_PATH}
+export PYTHONPATH=/cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc10-opt/lib/python3.9/site-packages
+
+# --- git from LCG_101
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-e475b/x86_64-centos7-gcc10-opt/bin:${PATH}
+export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-e475b/x86_64-centos7-gcc10-opt/libexec/git-core
+
+# --- use a suitable mysql (also LCG_101)
+export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.4.20-c0154/x86_64-centos7-gcc10-opt
+'''
+# before starting the installation
+#================================================================================
+
+
+
+# --------- install dir ------------------------------------------------------
+# ===========================================================
+# Modify this path to where you want to install the software
+# ===========================================================
+#
+
+if installPrefix is None:
+    ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+else:
+    ilcsoft_install_prefix = installPrefix
+
+# ----------------------------------------------------------------------------
+#--- the ilcsoft_release is now automatically appended in release-ilcsoft.cfg
+#     but not in release-base.cfg !!
+
+#append_version_to_install_prefix = False
+#if(append_version_to_install_prefix):
+#    ilcsoft_install_dir = os.path.join(ilcsoft_install_prefix , ilcsoft_release )
+
+# ----------------------------------------------------------------------------
+
+
+# --------- ilcsoft home -----------------------------------------------------
+# ===========================================================
+# Modify this path to where you want ilcinstall to look
+# for pre-installed (base) packages
+# typically this would be left to ilcsoft_install_prefix
+# or set to an /afs or /cvmfs base installation that you
+# want to use
+# ===========================================================
+
+ilcPath = ilcsoft_install_prefix
+# ----------------------------------------------------------------------------
+
+
+#--------------------------------------------------------------------------
+#ilcPatchPath = "/afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5/v01-15"
+
+
+
+# ======================= PACKAGES WITH NO INSTALL SUPPORT ===================
+
+# these packages need to be pre-installed for your system
+# please adjust the path variables accordingly
+
+# detect the default software installation path
+# when using package manager like apt-get, yum or brew
+platfDefault = None
+
+if platform.system().lower().find('linux') >= 0:
+   platfDefault = '/usr'
+elif platform.system().lower().find('darwin') >= 0:
+   platfDefault = '/usr/local'
+
+# ----- mysql --------------------------------------------------------
+MySQL_version = "10.4.20"
+MySQL_path = platfDefault
+
+# overwrite with a patch set in the environment
+my_mysql_path = os.getenv("MYSQL_DIR", default=None)
+if( my_mysql_path !=  None ):
+    MySQL_path = my_mysql_path
+
+# ----------------------------------------------------------------------------
+
+##########################################################################################
+#
+#  end of user configuration section
+#  only make changes below if you know what you are doing ...
+#
+##########################################################################################
+
+
+
+# ======================= PACKAGE VERSIONS ===================================
+
+Geant4_version =  "11.0.2"
+
+CLHEP_version =  "2.4.5.3"
+
+ROOT_version = "6.24.06"
+
+GSL_version = "2.7"
+
+Qt5_version = "v5.13.1"
+
+CMake_version = "3.23.2"
+
+CED_version = "v01-09-04"
+
+SIO_version = "v00-01"
+
+Boost_version = "1.77.0"
+
+Eigen_version = "3.4.0"
+
+# -------------------------------------------
+
+CondDBMySQL_version = "CondDBMySQL_ILC-0-9-7"
+
+ILCUTIL_version = "v01-06-02"
+
+FastJet_version = "3.4.0"
+
+FastJetcontrib_version = "1.049"
+
+# xerces-c (needed by geant4 for building gdml support - required by mokka)
+XercesC_version = "v3.2.3"
+XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
+
+# -------------------------------------------
+
+LCIO_version = "v02-17-01"
+
+GEAR_version = "v01-09-01"
+
+MarlinFastJet_version = "v00-05-03"
+
+KalTest_version = "v02-05-01"
+
+KalDet_version = "v01-14-01"
+
+aidaTT_version = "v00-10"
+
+DDKalTest_version = "v01-07"
+
+MarlinTrk_version = "v02-09-01"
+
+MarlinTrkProcessors_version = "v02-12-01"
+
+Clupatra_version = "v01-03"
+
+KiTrack_version = "v01-10"
+
+KiTrackMarlin_version = "v01-13-01"
+
+ForwardTracking_version = "v01-14-01"
+
+ConformalTracking_version = "v01-11"
+
+LICH_version = "v00-01"
+
+GBL_version = "v02-02-01"
+
+LCCD_version = "v01-05-01"
+
+RAIDA_version = "v01-09"
+
+MarlinUtil_version = "v01-16-02"
+
+Marlin_version = "v01-17-01"
+
+MarlinDD4hep_version = "v00-06-01"
+
+DDMarlinPandora_version = "v00-12"
+
+MarlinReco_version = "v01-33"
+
+FCalClusterer_version = "v01-00-03"
+
+ILDPerformance_version = "v01-10"
+
+ILDConfig_version = "v02-03"
+
+LCFIVertex_version = "v00-08"
+
+LCFIPlus_version = "v00-10-01"
+
+MarlinKinfit_version = "v00-06-01"
+
+MarlinKinfitProcessors_version = "v00-05"
+
+PandoraPFANew_version = "v03-25-03"
+
+PandoraAnalysis_version = "v02-00-01"
+
+CEDViewer_version = "v01-19-01"
+
+Overlay_version = "v00-22-04"
+
+PathFinder_version = "v00-06-01"
+
+MarlinTPC_version = "v01-07"
+
+LCTuple_version = "v01-14"
+
+BBQ_version = "v00-01-04"
+
+# Druid_version = "HEAD" # "2.2" # "1.8"
+
+Garlic_version = "v03-01"
+
+DD4hep_version = "v01-20-02"
+
+DD4hepExamples_version = "v01-20-02"
+
+lcgeo_version = "v00-16-08"
+
+podio_version = "v00-14-03"
+
+edm4hep_version = "v00-05"
+
+Physsim_version = "v00-04-02"

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -180,7 +180,7 @@ ConformalTracking_version = "v01-11"
 
 LICH_version = "v00-01"
 
-GBL_version = "v02-02-01"
+GBL_version = "V02-02-01"
 
 LCCD_version = "v01-05-01"
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Major upgrades to external software, most importantly **switching from python2 to python3**, and to newer version of gcc.
- Update all external software to latest available versions
- Include latest versions of iLCSoft packages
  - CED v01-09-04
  - MarlinFastJet v00-05-03
  - MarlinReco v01-33
  - lcgeo v00-16-08
  - CEDViewer v01-19-01
  - KalTest v02-05-01
  - DDKalTest v01-07
  - LCIO v02-17-01
  - MarlinKinfitProcessors v00-05
  - LCCD v01-05-01 
  - GEAR v01-09-01 
  - MarlinDD4hep v00-06-01 
  - MarlinUtil v01-16-02 
  - MarlinTrk v02-09-01 
  - MarlinTrkProcessors v02-12-01 
  - MarlinKinfit v00-06-01 
  - Overlay v00-22-04 
  - KiTrackMarlin v01-13-01 
  - ForwardTracking v01-14-01 
  - LCTuple v01-14
  - ILDConfig v02-03
  - Physsim v00-04-02
 
ENDRELEASENOTES