### PR TITLE
ilcinstall: set GIT_EXEC_PATH if existed in original setup

### DIFF
--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -443,6 +443,10 @@ class ILCSoft:
         ccompiler = self.env["CC"]
         f.write( 'export CC=' + ccompiler + os.linesep )
 
+        # set GIT_EXEC_PATH inherited from the setup.sh
+        if os.environ.get("GIT_EXEC_PATH"):
+            f.write('export GIT_EXEC_PATH=%s' % os.environ.get("GIT_EXEC_PATH"))
+
         #----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that `GIT_EXEC_PATH` is also present in `init_ilcsoft.sh` if it has been present in the build environment to ensure git is usable.

ENDRELEASENOTES

Initially triggered by: https://github.com/iLCSoft/MarlinUtil/pull/31#issuecomment-1256280728