### PR TITLE
Disable packages living on decomissioned svn server

### DIFF
--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         py_version: ['2.7.x', '3.7']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.py_version }}
     - name: Install requirements

--- a/ilcsoft/cernlib.py
+++ b/ilcsoft/cernlib.py
@@ -183,7 +183,7 @@ class CERNLIB(BaseILC):
         #os.chdir( self.installPath + "/build" )
 
         ## delete object files
-        os_system( "find "+self.installPath + "/build -type f -name *.o -exec rm -f {} \;" )
+        os_system( "find "+self.installPath + r"/build -type f -name *.o -exec rm -f {} \;" )
 
     def postCheckDeps(self):
         BaseILC.postCheckDeps(self)

--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -80,7 +80,7 @@ class ILCSoft:
         #fg: release_string might be empty, e.g. if lsb_release does not exis (MacOs)
         self.release_number = '-1'
         if len( release_string ): 
-            self.release_number = release_string[re.search('\d', release_string).start()]
+            self.release_number = release_string[re.search(r'\d', release_string).start()]
         
         for k,v in self.debugInfo.items():
             print("+", k, '\t', str(v).replace("\n","\n\t\t"))

--- a/ilcsoft/ninja.py
+++ b/ilcsoft/ninja.py
@@ -54,7 +54,7 @@ class ninja(BaseILC):
     def cleanupInstall(self):
         BaseILC.cleanupInstall(self)
         os.chdir( self.installPath )
-        os_system( "find . \! -name 'ninja' -delete" )
+        os_system( r"find . \! -name 'ninja' -delete" )
 
     def postCheckDeps(self):
         BaseILC.postCheckDeps(self)

--- a/ilcsoft/test_version.py
+++ b/ilcsoft/test_version.py
@@ -3,30 +3,30 @@
 ################################################
 
 from .version import Version
-import py
+import pytest
 
 def test_sanity():
-    py.test.raises(TypeError, Version )
-    py.test.raises(ValueError, Version, 0)
-    py.test.raises(ValueError, Version, [])
-    py.test.raises(ValueError, Version, '')
-    py.test.raises(ValueError, Version, '1')
-    py.test.raises(ValueError, Version, '1.')
-    py.test.raises(ValueError, Version, 'a.b')
-    py.test.raises(ValueError, Version, 'blah')
+    pytest.raises(TypeError, Version )
+    pytest.raises(ValueError, Version, 0)
+    pytest.raises(ValueError, Version, [])
+    pytest.raises(ValueError, Version, '')
+    pytest.raises(ValueError, Version, '1')
+    pytest.raises(ValueError, Version, '1.')
+    pytest.raises(ValueError, Version, 'a.b')
+    pytest.raises(ValueError, Version, 'blah')
 
 def test_general():
 
     MIN_ELEM = Version._min_elements
 
     # versions must have at least one element > 0
-    py.test.raises(ValueError, Version, MIN_ELEM * (0,) )
+    pytest.raises(ValueError, Version, MIN_ELEM * (0,) )
 
     # elements must be integers or convertible to int
-    py.test.raises(ValueError, Version, (MIN_ELEM * [1]) + ['a'] )
+    pytest.raises(ValueError, Version, (MIN_ELEM * [1]) + ['a'] )
 
     # elements must be >= 0
-    py.test.raises(ValueError, Version, (MIN_ELEM * [1]) + [-1] )
+    pytest.raises(ValueError, Version, (MIN_ELEM * [1]) + [-1] )
 
     # cutting off / filling missing elements
     MAX_ELEM = 4

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -202,16 +202,16 @@ ilcsoft.module("LICH").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinUtil' ]
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='trunk'
 
 
-ilcsoft.install( PathFinder( PathFinder_version ))
-ilcsoft.module("PathFinder").download.type="svn"
+# ilcsoft.install( PathFinder( PathFinder_version ))
+# ilcsoft.module("PathFinder").download.type="svn"
 
-ilcsoft.install( MarlinTPC( MarlinTPC_version ))
-ilcsoft.module("MarlinTPC").download.type="svn"
-ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
+# ilcsoft.install( MarlinTPC( MarlinTPC_version ))
+# ilcsoft.module("MarlinTPC").download.type="svn"
+# ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
 
 
-ilcsoft.install( BBQ( BBQ_version ))
-ilcsoft.module("BBQ").download.type="svn"
+# ilcsoft.install( BBQ( BBQ_version ))
+# ilcsoft.module("BBQ").download.type="svn"
 
 #fg: needs porting to ROOT6 (dictionary!)
 #ilcsoft.install( Druid( Druid_version ))

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -199,17 +199,16 @@ ilcsoft.module("LICH").addDependency( [ 'LCIO', 'ROOT', 'Marlin', 'MarlinUtil' ]
 #ilcsoft.module("Eutelescope").env['EUDAQ_VERSION']='trunk'
 #ilcsoft.module("Eutelescope").env['MILLEPEDEII_VERSION']='trunk'
 
+# ilcsoft.install( PathFinder( PathFinder_version ))
+# ilcsoft.module("PathFinder").download.type="svn"
 
-ilcsoft.install( PathFinder( PathFinder_version ))
-ilcsoft.module("PathFinder").download.type="svn"
-
-ilcsoft.install( MarlinTPC( MarlinTPC_version ))
-ilcsoft.module("MarlinTPC").download.type="svn"
-ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
+# ilcsoft.install( MarlinTPC( MarlinTPC_version ))
+# ilcsoft.module("MarlinTPC").download.type="svn"
+# ilcsoft.module("MarlinTPC").envcmake['INSTALL_DOC']='ON'
 
 
-ilcsoft.install( BBQ( BBQ_version ))
-ilcsoft.module("BBQ").download.type="svn"
+# ilcsoft.install( BBQ( BBQ_version ))
+# ilcsoft.module("BBQ").download.type="svn"
 
 #fg: needs porting to ROOT6 (dictionary!)
 #ilcsoft.install( Druid( Druid_version ))

--- a/scripts/tagging/parseversion.py
+++ b/scripts/tagging/parseversion.py
@@ -57,7 +57,7 @@ class Version( object ):
       elif 'pre' in parts[2]:
         self.pre = int(parts[2].strip('pre'))
       else:
-        self.patch = int( parts[2] )
+        self.patch = int( parts[2].strip('p') )
 
     if len(parts) >= 4:
       if 'pre' == parts[3]:

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -211,7 +211,7 @@ class TestGit( unittest.TestCase ):
                 }
               ]
 
-    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+    with self.assertRaisesRegex( RuntimeError, "Invalid version required"), \
          patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
       self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20-pre", preRelease=True, dryRun=True)
 
@@ -225,7 +225,7 @@ class TestGit( unittest.TestCase ):
                   "tarball_url": "tarball/v0.1"
                 }
               ]
-    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+    with self.assertRaisesRegex( RuntimeError, "Invalid version required"), \
          patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
       self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-19", preRelease=True, dryRun=True)
 
@@ -241,7 +241,7 @@ class TestGit( unittest.TestCase ):
               ]
 
 
-    with self.assertRaisesRegexp( RuntimeError, "Invalid version required"), \
+    with self.assertRaisesRegex( RuntimeError, "Invalid version required"), \
          patch( "tagging.gitinterface.Repo.getGithubTags", new=Mock( return_value=myTagInfo)):
       self.repo = Repo(owner="tester", repo="testrepo", branch="testbranch", newVersion="v01-03-20-pre1", preRelease=True, dryRun=True)
 

--- a/scripts/tests/Test_Tagging.py
+++ b/scripts/tests/Test_Tagging.py
@@ -11,7 +11,13 @@ try:
 except ImportError:  # for python3
   import builtins
   builtin_module_name = 'builtins'
+
 import unittest
+try: # monkey patch python2 to also use non-deprecated functionality
+  unittest.TestCase.assertRaisesRegex
+except AttributeError:
+  unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+
 import os
 import shutil
 import sys


### PR DESCRIPTION
DESY SVN server has been decomissioned and some test beam packages have not yet been migrated to gitlab repositories. For now, disabling these packages for HEAD and v02-03 releases.



BEGINRELEASENOTES
- Disable `PathFinder`, `MarlinTPC`, and `BBQ` packages from being installed by default for, as they are no longer available from the DESY SVN server and have not yet been fully migrated to the DESY gitlab server.
- Fix tests to work with latest versions of `pytest`. The main reason is that starting with pytest 7.2.0(?) py.test.raises only works if py is also installed. Given https://github.com/pytest-dev/py/issues/288 it is probably easiest to just use pytest directly if possible.
- Fix a few escape sequence warnings in packages.

ENDRELEASENOTES