### PR TITLE
Make physsim work with updated CMake config

### DIFF
--- a/ilcsoft/__init__.py
+++ b/ilcsoft/__init__.py
@@ -40,7 +40,8 @@ from .ckfit import CKFit
 from .fastjet import FastJet, FastJetClustering
 from .marlintrk import MarlinTrk
 from .kitrack import KiTrack, KiTrackMarlin
-#from ddmarlinpandora import DDMarlinPandora 
+from .physsim import Physsim
+#from ddmarlinpandora import DDMarlinPandora
 
 #slic et al
 from .gdml import GDML

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -6,7 +6,9 @@
 # Date: Jan, 2007
 #
 ##################################################
-                                                                                                                                                            
+
+import os
+
 # custom imports
 from .baseilc import BaseILC
 from .util import *
@@ -60,6 +62,8 @@ class MarlinPKG(BaseILC):
 
         # fill MARLIN_DLL
         if( self.name != "MarlinUtil" and self.name != "PandoraPFANew" ):
-            self.parent.module('Marlin').envpath["MARLIN_DLL"].append( 
-                self.installPath+"/lib/lib"+self.name+self.shlib_ext )
-
+            for libdir in ("/lib/", "/lib64/"):
+                libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
+                if os.path.exists(libname):
+                    self.parent.module('Marlin').envpath["MARLIN_DLL"].append(libname)
+                    break

--- a/ilcsoft/physsim.py
+++ b/ilcsoft/physsim.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from .marlinpkg import MarlinPKG
+
+class Physsim(MarlinPKG):
+    """Responsible for the Physsim installation"""
+
+    def __init__(self, userInput):
+        MarlinPKG.__init__(self, "Physsim", userInput)
+        self.reqfiles = [ ["lib/libPhyssim.so", "lib64/libPhyssim.so", "lib/libPhyssim.dylib"] ]
+        self.reqmodules = ["LCIO", "ROOT"]
+        self.hasCMakeFindSupport = True

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -164,8 +164,7 @@ ilcsoft.install( MarlinPKG( "Clupatra", Clupatra_version ))
 ilcsoft.module("Clupatra").hasCMakeFindSupport=True
 ilcsoft.module("Clupatra").addDependency( [ 'LCIO', 'ROOT', 'RAIDA', 'Marlin', 'MarlinUtil', 'KalTest', 'MarlinTrk' ] )
 
-ilcsoft.install( MarlinPKG( "Physsim", Physsim_version ))
-ilcsoft.module("Physsim").addDependency( [ 'LCIO', 'ROOT', 'Marlin' ] )
+ilcsoft.install(Physsim(Physsim_version))
 
 ilcsoft.install( MarlinPKG( "FCalClusterer", FCalClusterer_version ))
 # Special case: BeamCalRecoConfig.cmake is generated in FCalClusterer

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -162,8 +162,7 @@ ilcsoft.install( MarlinPKG( "Clupatra", Clupatra_version ))
 ilcsoft.module("Clupatra").hasCMakeFindSupport=True
 ilcsoft.module("Clupatra").addDependency( [ 'LCIO', 'ROOT', 'RAIDA', 'Marlin', 'MarlinUtil', 'KalTest', 'MarlinTrk' ] )
 
-ilcsoft.install( MarlinPKG( "Physsim", Physsim_version ))
-ilcsoft.module("Physsim").addDependency( [ 'LCIO', 'ROOT', 'Marlin' ] )
+ilcsoft.install( Physsim(Physsim_version) )
 
 ilcsoft.install( MarlinPKG( "FCalClusterer", FCalClusterer_version ))
 # Special case: BeamCalRecoConfig.cmake is generated in FCalClusterer


### PR DESCRIPTION
BEGINRELEASENOTES
- Make `Physsim` its own package to accomodate more easily for changed behavior after CMake config updates in iLCSoft/Physsim#2
- Make `MarlinPKG` slightly more clever for discovering libraries that need to be put on `MARLIN_DLL`

ENDRELEASENOTES

- [x] Make a HEAD installation with this to see if things work as expected.