### PR TITLE
Prepare v02-03-02 patch release

### DIFF
--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -1,0 +1,121 @@
+# iLCSoft v02-03-02
+
+Patch release for the v02-03 development series (see the [v02-03 release notes](https://github.com/iLCSoft/iLCInstall/blob/master/doc/release_notes_ilcsoft_v02-03.md) for more details about this series).
+
+## External software versions upgrade
+DD4hep 01-20-02 :arrow_right: 01-25-01
+
+## New packages
+
+None
+
+
+
+## Packages changed wrt. v02-03-01
+
+### iLCUtil
+- [ ] TODO: merge open PR, tag
+
+### MarlinReco
+- [ ] TODO: merge open PRs, tag
+
+### podio
+- [ ] TODO: add lates tag (potentially make a new tag before)
+
+### EDM4hep
+- [ ] TODO: add latest tag
+
+### LCIO v02-20
+* 2023-05-30 Andre Sailer ([PR#168](https://github.com/iLCSoft/LCIO/pull/168))
+  - Pregenerated Headers: remove self-include from some headers (breaks include-what-you-use)
+  - LCIterator, LCRTRelations: remove template syntax causing errors in gcc13/c++20
+  - RunEvent, LCObject, TrackStateImpl: added default copy and move constructor and assignment operator to avoid error about "'definition of implicit copy constructor for 'LCObject' is deprecated because it has a user-declared destructor'"
+
+* 2023-05-12 tmadlener ([PR#167](https://github.com/iLCSoft/LCIO/pull/167))
+  - Fix checking of collection types to make sure patching works correctly
+
+* 2023-05-03 Thomas Madlener ([PR#166](https://github.com/iLCSoft/LCIO/pull/166))
+  - Upgrade `python-lint` workflow to run on `ubuntu-lates` since `ubuntu-18.04` runners have been removed.
+
+* 2023-05-03 Finn Johannsen ([PR#165](https://github.com/iLCSoft/LCIO/pull/165))
+  - Fixes to the on the fly collection patching that are necessary for the LCIO to EDM4hep standalone conversion.
+    - Make `CheckCollections` check the `FromType` and `ToType` collection parameters to figure out the involved types for `LCRelations`. Add them to the output of `CheckCollections::print`
+    - Make the `CheckCollectoins::patchCollections` parse these strings back for `LCRelation` collections and set them as collection parameters for collections it creates on the fly.
+    - Add a `--minimal` flag to `check_missing_cols` in order to make it possible to produce outputs that can be more easily consumbed by other programs.
+
+* 2023-05-03 Thomas Madlener ([PR#164](https://github.com/iLCSoft/LCIO/pull/164))
+  - Add Key4hep release based CI workflow
+  - Fix remaining warnings to enable `-Werror`
+  - Update *checkout* action to v3, since v2 is deprecated. 
+  - **CLHEP >= 2.0** is now required for building the examples that use CLHEP functionality (`test_fourvector`).
+
+* 2023-02-10 jmcarcell ([PR#162](https://github.com/iLCSoft/LCIO/pull/162))
+  - Add test dependencies so that tests can run in parallel
+
+* 2023-02-10 jmcarcell ([PR#161](https://github.com/iLCSoft/LCIO/pull/161))
+  - Remove the deprecated C API and fortran bindings (c.f. [#137](https://github.com/iLCSoft/LCIO/pull/137) and [#151](https://github.com/iLCSoft/LCIO/issues/151))
+
+### LCIO v02-19-01
+* 2023-02-06 Bohdan Dudar ([PR#163](https://github.com/iLCSoft/LCIO/pull/163))
+  - `getRelatedTo(From)MaxWeightObject()` and `getRelatedTo(From)MaxWeight()` now accept generic decode function of `float(float)` signature as a second argument, which specifies how to decode the weight. Default option is identity function (just compares weights as they are).
+  - Helper functions to decode and encode "track"/"cluster" specific weights from PFO-MCParticle LCRelation collection are added to MarlinUtil in [MarlinUtil#36](https://github.com/iLCSoft/MarlinUtil/pull/36).
+
+* 2023-02-03 jmcarcell ([PR#160](https://github.com/iLCSoft/LCIO/pull/160))
+  - Fix a compiler warning about `strncpy` usage
+  
+### k4geo (lecgeo) v00-18-01
+
+* 2023-05-26 jmcarcell ([PR#274](https://github.com/key4hep/k4geo/pull/274))
+  - Change eps_min to .001 in the example steering file
+
+* 2023-04-10 Frank Gaede ([PR#266](https://github.com/key4hep/k4geo/pull/266))
+  -  add definitions of regions to the SEcal06_hybrid barrel and endcap models of ILD:
+       - `EcalBarrelRegion` and `EcalEndcapRegion`
+       - these can be used for fast simulation (ML generation)
+
+* 2023-01-13 Daniel Jeans ([PR#263](https://github.com/key4hep/k4geo/pull/263))
+  - deal with case when previousStep is not yet defined (could cause crash)
+  - add timing information to the lowPt hits
+ 
+### MarlinUtil v01-17-01
+
+* 2023-05-30 Andre Sailer ([PR#40](https://github.com/iLCSoft/MarlinUtil/pull/40))
+  - CMake: make sure DD4hep include directories come first
+
+* 2023-05-30 tmadlener ([PR#38](https://github.com/iLCSoft/MarlinUtil/pull/38))
+  - Add a CI workflow based on the Key4hep release and nightly builds
+
+* 2023-05-30 Bohdan Dudar ([PR#37](https://github.com/iLCSoft/MarlinUtil/pull/37))
+  - Added `DD4hep::DDRec` library as a dependency to avoid undefined reference symbol errors using `dd4hep::rec` features. Fixes #26
+
+* 2023-02-06 Bohdan Dudar ([PR#36](https://github.com/iLCSoft/MarlinUtil/pull/36))
+  - Add function to extract decoded Track and Cluster weights from encoded LCRelation collection for PFO/MCParticles.
+  - Add comparator functions for these weights encodings
+
+### RAIDA v01-10
+
+* 2023-04-18 tmadlener ([PR#5](https://github.com/iLCSoft/RAIDA/pull/5))
+  - Migrate CI to github actions and remove travis-CI based configuration.
+
+* 2023-04-18 jmcarcell ([PR#4](https://github.com/iLCSoft/RAIDA/pull/4))
+  - Link only against the ROOT libraries that are necessary to avoid downstream linker problems.
+
+### ConformalTracking v01-11-01
+
+* 2023-05-25 Andre Sailer ([PR#60](https://github.com/iLCSoft/ConformalTracking/pull/60))
+  - ParameterParser: fix linking issue with recent versions of boost
+  - ParameterParser: move to non-deprecated header file location
+  
+### MarlinTrkProcessors v02-12-03
+
+* 2022-12-02 Thomas Madlener ([PR#64](https://github.com/iLCSoft/MarlinTrkProcessors/pull/64))
+  - Remove the obsolote gcc8 based workflow and update github actions to the latest versions
+
+### Overlay v00-23
+
+* 2023-05-02 tmadlener ([PR#27](https://github.com/iLCSoft/Overlay/pull/27))
+  - Remove no longer available gcc8 based workflow from CI
+  - Update github actions to latest available versions
+
+* 2023-05-02 scott snyder ([PR#26](https://github.com/iLCSoft/Overlay/pull/26))
+  - OverlayTiming,OverlayTimingGeneric: Added property Start_Integration_Time to allow changing the starting integration time.  This defaults to the previously hardcoded value of -0.25, but may need to be moved earlier if vertex smearing is enabled.

--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -9,9 +9,27 @@ Patch release for the v02-03 development series (see the [v02-03 release notes](
 
 ## New packages
 
-### k4EDM4hep2LcioConv (ilcsoft)
-* [ ] TODO: tag
-* [key4hep/k4EDM4hep2LcioConv](https://github.com/key4hep/k4EDM4hep2LcioConv)
+### k4EDM4hep2LcioConv v00-05 (ilcsoft)
+Package containing converters for LCIO to EDM4hep, and vice versa, as well as a
+standalone `lcio2edm4hep` conversion executable. Repository: [key4hep/k4EDM4hep2LcioConv](https://github.com/key4hep/k4EDM4hep2LcioConv)
+
+* 2023-07-10 tmadlener ([PR#23](https://github.com/key4hep/k4EDM4hep2LcioConv/pull/23))
+  - Remove the explicit `clang-format-check` workflow as it is also covered by the `pre-commit` workflow.
+
+* 2023-07-10 Frank Gaede ([PR#20](https://github.com/key4hep/k4EDM4hep2LcioConv/pull/20))
+  - Add the possibility to convert only a subset of collections and events.
+  - Fix minor bug in TrackState conversion (covMatrix[15])
+  - Write `AllCaloHitContributionsCombined` only if needed, i.e. `SimCalorimeterHits` are present in the events in lcio2edm4hep
+
+* 2023-06-13 Finn Johannsen ([PR#11](https://github.com/key4hep/k4EDM4hep2LcioConv/pull/11))
+  - Add LCIO to EDM4hep conversion functionality with a similar interface as the one that is already present for the other direction.
+
+* 2023-06-07 Thomas Madlener ([PR#16](https://github.com/key4hep/k4EDM4hep2LcioConv/pull/16))
+  - Match the renaming of `subdetectorHitNumbers` in EDM4hep (cf. [key4hep/EDM4hep#188](https://github.com/key4hep/EDM4hep/pull/188))
+  - Introduce some guards for the `TPCHit` -> `RawTimeSeries` change in EDM4hep (cf. [key4hep/EDM4hep#179](https://github.com/key4hep/EDM4hep/pull/179))
+
+* 2023-04-19 Leonhard Reichenbach ([PR#13](https://github.com/key4hep/k4EDM4hep2LcioConv/pull/13))
+  - Add support for EventHeader conversion
 
 ## Packages changed wrt. v02-03-01
 

--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -147,22 +147,27 @@ standalone `lcio2edm4hep` conversion executable. Repository: [key4hep/k4EDM4hep2
   - Data model comparison tool w/ simple heuristics to identify potential omissions / mistakes (e.g. checking for the limits of the ROOT backend)
   - Changed handling of backwards compatibility for the collection info metadata
 
-### EDM4hep v00-09
+### EDM4hep v00-10
 
-* 2023-05-03 Thomas Madlener ([PR#152](https://github.com/key4hep/EDM4hep/pull/152))
-  - Add a `EDM4hepVersion.h` file that has the same basic structure and functionality as other Key4hep packages.
+* 2023-07-07 BrieucF ([PR#212](https://github.com/key4hep/EDM4hep/pull/212))
+  - Add a script to automatically update the README.md links
 
-* 2023-05-02 jmcarcell ([PR#193](https://github.com/key4hep/EDM4hep/pull/193))
-  - Add a configuration file for the new podio visualization tool
+* 2023-07-04 tmadlener ([PR#209](https://github.com/key4hep/EDM4hep/pull/209))
+  - Add brief documentation of the `edm4hep2json` tool with minimal documentation of the output JSON schema.
 
-* 2023-04-28 jmcarcell ([PR#203](https://github.com/key4hep/EDM4hep/pull/203))
-  - Remove root version check inside CMakeLists.txt
+* 2023-06-30 jmcarcell ([PR#207](https://github.com/key4hep/EDM4hep/pull/207))
+  - Improve python API, use `import edm4hep` instead of `from edm4hep import edm4hep`
 
-* 2023-04-26 jmcarcell ([PR#205](https://github.com/key4hep/EDM4hep/pull/205))
-  - Add missing units to the comments
+* 2023-06-29 tmadlener ([PR#206](https://github.com/key4hep/EDM4hep/pull/206))
+  - Replace TPCHit with RawTimeSeries
+  - Update version to 0.9
+  - Add TrackerPulse
 
-* 2023-04-23 Thomas Madlener ([PR#200](https://github.com/key4hep/EDM4hep/pull/200))
-  - Add `schema_version` to YAML definition now that podio has limited support (see AIDASoft/podio#341)
+* 2023-06-14 jmcarcell ([PR#204](https://github.com/key4hep/EDM4hep/pull/204))
+  - Add python bindings for the datamodel classes and some documentation on how to use the bindings
+
+* 2023-06-07 FinnJohannsen ([PR#188](https://github.com/key4hep/EDM4hep/pull/188))
+  - Changed the name of one VectorMember of edm4hep::track from subDetectorHitNumbers to subdetectorHitNumbers to be consistent with other spellings of the word subdetector in the yaml file and in LCIO.
 
 ### iLCUtil v01-07-01
 

--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -276,3 +276,8 @@ standalone `lcio2edm4hep` conversion executable. Repository: [key4hep/k4EDM4hep2
   - PID algorithm for PDG MC-Reco plot
   - plot folder
 
+### ILDConfig v02-03-02
+
+* 2023-02-24 Jan Klamka ([PR#134](https://github.com/iLCSoft/ILDConfig/pull/134))
+  - Digitisation including the hits from CLIC-like outer tracker and changes for the FTD, allowing for further use of the Conformal Tracking
+  - Conformal tracking with input collections from the new ILD_l5_v09 model, parameters setup as in CLIC config.

--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -3,29 +3,153 @@
 Patch release for the v02-03 development series (see the [v02-03 release notes](https://github.com/iLCSoft/iLCInstall/blob/master/doc/release_notes_ilcsoft_v02-03.md) for more details about this series).
 
 ## External software versions upgrade
-- DD4hep 01-20-02 :arrow_right: 01-25-0
+- DD4hep 01-20-02 :arrow_right: 01-25-01
 - ROOT 6.24/06 :arrow_right: 6.28/04
 - Geant4 11.0.2 :arrow_right: 11.1.1
 
 ## New packages
 
-None
-
-
+### k4EDM4hep2LcioConv (ilcsoft)
+* [ ] TODO: tag
+* [key4hep/k4EDM4hep2LcioConv](https://github.com/key4hep/k4EDM4hep2LcioConv)
 
 ## Packages changed wrt. v02-03-01
 
-### iLCUtil
-- [ ] TODO: merge open PR, tag
+### MarlinReco v01-34
 
-### MarlinReco
-- [ ] TODO: merge open PRs, tag
+* 2023-07-07 tmadlener ([PR#124](https://github.com/iLCSoft/MarlinReco/pull/124))
+  - Usage of new utility functionality requires a newer version of `MarlinUtil`
 
-### podio
-- [ ] TODO: add lates tag (potentially make a new tag before)
+* 2023-07-07 yradkhorrami ([PR#123](https://github.com/iLCSoft/MarlinReco/pull/123))
+  - Merge SLDCorrection to MarlinReco
+  - First implementation of SLDCorrection: for the time being, done only on semi-leptonic decays of bottom hadrons in b-jets
 
-### EDM4hep
-- [ ] TODO: add latest tag
+* 2023-07-07 Leonhard Reichenbach ([PR#121](https://github.com/iLCSoft/MarlinReco/pull/121))
+  - LeptonID: remove notebook output
+
+* 2023-07-04 Ulrich Einhaus ([PR#118](https://github.com/iLCSoft/MarlinReco/pull/118))
+  Comprehensive Particle Identification Processor: First beta version of CPID.
+  Extracts PID-related observables from PFOs and combines them in a training model, which can be inferred afterwards to data.
+  This release contains the initial version of the Marlin processor with an example steering file, the input algorithm generic class + manager along with a library of different input algorithms, corresponding to different PID observables, as well as the training model generic class + manager along with a library of predefined models for training and inference.
+  The selection of algorithms and models is handled via the processor steering file.
+  The managers allow to add new modules (algorithms and models), compile and use them via the steering file, without the necessity to touch any other files.
+  ComprehensivePIDProcessor.h contains a ReadMe section with an explanation of all processor steering parameters.
+
+* 2023-07-03 Bohdan Dudar ([PR#117](https://github.com/iLCSoft/MarlinReco/pull/117))
+  - In case of the option to measure time-of-flight at the SET: now using raw (digitized strips) SET hits instead of simulated hits. It doesn't change anything now, but could become trouble in the future when proper time digitization is added.
+
+* 2023-06-29 Leonhard Reichenbach ([PR#120](https://github.com/iLCSoft/MarlinReco/pull/120))
+  - LeptonID: update weights
+
+* 2023-06-13 tmadlener ([PR#115](https://github.com/iLCSoft/MarlinReco/pull/115))
+  - Bump the minimal required cmake version to 3.12
+  - Fix the order in which DD4hep and LCIO appear in the libraries to link against to make sure to not pick an inappropriate version from the underlying environment
+
+* 2023-06-13 Leonhard Reichenbach ([PR#114](https://github.com/iLCSoft/MarlinReco/pull/114))
+  - Added `LeptonIDProcessor` to identify electrons and muons in jets using boosted decision trees.
+
+* 2023-06-12 tmadlener ([PR#116](https://github.com/iLCSoft/MarlinReco/pull/116))
+  - Switch from `dd4hep::long64` to `dd4hep::CellID` to be compatible with DD4hep after [AIDASoft/DD4hep#1125](https://github.com/AIDASoft/DD4hep/pull/1125)
+
+* 2023-06-07 Bohdan Dudar ([PR#113](https://github.com/iLCSoft/MarlinReco/pull/113))
+  - Always use the first (before)  --> latest (now) curl in the track to get extrapolated track position at the calorimeter surface. This gives sometimes better estimate of the track position at the ECAL surface, especially for the tracks with large number of curls. Thus  new version gives better time of flight correction for the distance to the surface and thus TOF itself.
+  - Minor style improvements
+
+* 2023-06-07 Bohdan Dudar ([PR#112](https://github.com/iLCSoft/MarlinReco/pull/112))
+  - Switch to the helix formula without Omega: $\ell_{i} = \frac{|z_{i+1} - z_{i}|}{|\tan{\lambda_{i}}|}\sqrt{1 +\tan^2{\lambda_{i}}}$. It shows the best performance so far.
+  - Other bug fixes and consistency improvements.
+
+* 2023-05-11 Julie Munch Torndal ([PR#110](https://github.com/iLCSoft/MarlinReco/pull/110))
+  - Added `CheatedMCOverlayRemoval` processor to identify MC particles that are overlay and remove the corresponding PFOs from the collection. 
+    - See under [`Analysis/OverlayRemoval/example/CheatedMCOverlayRemoval.xml`](https://github.com/iLCSoft/MarlinReco/blob/master/Analysis/OverlayRemoval/example/CheatedMCOverlayRemoval.xml) for how to run processor
+
+* 2023-02-07 Bohdan Dudar ([PR#108](https://github.com/iLCSoft/MarlinReco/pull/108))
+  - Make encoding RecoParticle relation weights more explicit with a new encode function in MarlinUtil
+ 
+
+### podio v00-16-05
+
+* 2023-05-23 tmadlener ([PR#420](https://github.com/AIDASoft/podio/pull/420))
+  - Fix a version check inside the `ROOTReader` to avoid segmentation violations
+
+* 2023-05-23 tmadlener ([PR#417](https://github.com/AIDASoft/podio/pull/417))
+  - Fix an issue with reading multiple files via the `ROOTFrameReader` ([#411](https://github.com/AIDASoft/podio/issues/411))
+    - Add documentation for API of opening file(s)
+    - Add tests for reading multiple files
+
+* 2023-05-22 tmadlener ([PR#418](https://github.com/AIDASoft/podio/pull/418))
+  - Bring back the public templated `getMap` functionality for `podio::GenericParameters` as they are already used in DD4hep (see [AIDASoft/DD4hep#1112](https://github.com/AIDASoft/DD4hep/pull/1112)). 
+    - Mark the existing `getXYZMap` as deprecated but keep them for a brief transition period.
+    - These have been removed in [#415](https://github.com/AIDASoft/podio/pull/415).
+
+* 2023-05-19 jmcarcell ([PR#416](https://github.com/AIDASoft/podio/pull/416))
+  - Remove selection rules for classes that don't exist anymore
+
+* 2023-05-15 jmcarcell ([PR#415](https://github.com/AIDASoft/podio/pull/415))
+  - Remove the deprecated getters and setters from the generic parameters
+
+* 2023-05-15 jmcarcell ([PR#410](https://github.com/AIDASoft/podio/pull/410))
+  - Remove the square that is run when cmake runs
+
+* 2023-05-09 tmadlener ([PR#414](https://github.com/AIDASoft/podio/pull/414))
+  - Fix off-by-one error in `UserDataCollection::print` that caused the first element to be printed twice.
+
+* 2023-05-09 Thomas Madlener ([PR#394](https://github.com/AIDASoft/podio/pull/394))
+  - Introduce a `CollectionBufferFactory` that can create the necessary buffers from a collection type, a schema version and a subset collection flag.
+    - Use this factory throughout all existing Readers
+    - Remove `createBuffers` and `createSchemaEvolvableBuffers` from `podio::CollectionBase` interface
+  - Make the minimum allowed `schema_version` 1 in the yaml definition files. Default to 1 if no `schema_version` is provided
+  - Add a `schemaVersion` to the `DatamodelDefinition.h` header that is generated and that can be accessed via `{{ package_name }}::meta::schemaVersion`. Use this to propagate schema information to the necessary places.
+  - Make `SIOBlocks` write the current schema version, such that on reading they can generate the appropriate buffers for the version on file.
+
+* 2023-04-22 Christopher Dilks ([PR#408](https://github.com/AIDASoft/podio/pull/408))
+  - fix type inconsistency between `Collection::size()` and index for const object accessors
+
+* 2023-04-21 jmcarcell ([PR#387](https://github.com/AIDASoft/podio/pull/387))
+  - Make sure that the dump model round trip tests work without `ENABLE_SIO`
+  - Actually test the extension model dumping
+
+* 2023-04-12 Thomas Madlener ([PR#400](https://github.com/AIDASoft/podio/pull/400))
+  - Fix a bug in `SIOFrameData::getAvailableCollections` to also work with Frames where some of the collections have not been written and that could lead to a seg fault.
+  - Add a test for this in c++ (previously only covered in python unittests of Frame).
+
+* 2023-04-05 Thomas Madlener ([PR#399](https://github.com/AIDASoft/podio/pull/399))
+  - Add `PODIO_ENABLE_SIO=1` to the public `target_compile_definitions` for `podioSioIO` so that all dependent targets automatically get it as well. This should make it easier to use SIO dependent features in dependencies. 
+  - Consistently use a scope for `target_link_libraries` in tests.
+
+* 2023-04-03 Paul Gessinger-Befurt ([PR#398](https://github.com/AIDASoft/podio/pull/398))
+  - Do not reject building if ROOT was built with C++20 (instead of C++17).
+
+* 2023-04-03 Thomas Madlener ([PR#397](https://github.com/AIDASoft/podio/pull/397))
+  - Remove the `GENERATED` property from generated files in CMake to avoid inconsistent removal of headers and source files with the `clean` target. Fixes [#396](https://github.com/AIDASoft/podio/issues/396)
+
+* 2023-03-15 Benedikt Hegner ([PR#341](https://github.com/AIDASoft/podio/pull/341))
+  - Adding infrastructure for schema evolution
+  - Added explicit version tracking to the metadata
+  - Data model comparison tool w/ simple heuristics to identify potential omissions / mistakes (e.g. checking for the limits of the ROOT backend)
+  - Changed handling of backwards compatibility for the collection info metadata
+
+### EDM4hep v00-09
+
+* 2023-05-03 Thomas Madlener ([PR#152](https://github.com/key4hep/EDM4hep/pull/152))
+  - Add a `EDM4hepVersion.h` file that has the same basic structure and functionality as other Key4hep packages.
+
+* 2023-05-02 jmcarcell ([PR#193](https://github.com/key4hep/EDM4hep/pull/193))
+  - Add a configuration file for the new podio visualization tool
+
+* 2023-04-28 jmcarcell ([PR#203](https://github.com/key4hep/EDM4hep/pull/203))
+  - Remove root version check inside CMakeLists.txt
+
+* 2023-04-26 jmcarcell ([PR#205](https://github.com/key4hep/EDM4hep/pull/205))
+  - Add missing units to the comments
+
+* 2023-04-23 Thomas Madlener ([PR#200](https://github.com/key4hep/EDM4hep/pull/200))
+  - Add `schema_version` to YAML definition now that podio has limited support (see AIDASoft/podio#341)
+
+### iLCUtil v01-07-01
+
+* 2023-06-08 scott snyder ([PR#28](https://github.com/ilCSoft/iLCUtil/pull/28))
+  - Fix a compilation warning in ILCTest.h.
 
 ### LCIO v02-20
 * 2023-05-30 Andre Sailer ([PR#168](https://github.com/iLCSoft/LCIO/pull/168))
@@ -94,7 +218,7 @@ None
   - Add function to extract decoded Track and Cluster weights from encoded LCRelation collection for PFO/MCParticles.
   - Add comparator functions for these weights encodings
 
-### RAIDA v01-10
+### RAIDA v01-11
 
 * 2023-04-18 tmadlener ([PR#5](https://github.com/iLCSoft/RAIDA/pull/5))
   - Migrate CI to github actions and remove travis-CI based configuration.
@@ -121,3 +245,16 @@ None
 
 * 2023-05-02 scott snyder ([PR#26](https://github.com/iLCSoft/Overlay/pull/26))
   - OverlayTiming,OverlayTimingGeneric: Added property Start_Integration_Time to allow changing the starting integration time.  This defaults to the previously hardcoded value of -0.25, but may need to be moved earlier if vertex smearing is enabled.
+
+### ILDPerformance v01-12
+
+* 2023-06-26 tmadlener ([PR#40](https://github.com/iLCSoft/ILDPerformance/pull/40))
+  - Fix the CI workflow by making sure that the DD4hep headers appear early enough to have precedence over any headers that might be picked up from the underlying environment.
+  - Add a workflow based on the key4hep nightly builds
+
+* 2023-06-26 Ulrich Einhaus ([PR#39](https://github.com/iLCSoft/ILDPerformance/pull/39))
+  New options:
+  - lambda cut
+  - PID algorithm for PDG MC-Reco plot
+  - plot folder
+

--- a/doc/release_notes_ilcsoft_v02-03-02.md
+++ b/doc/release_notes_ilcsoft_v02-03-02.md
@@ -3,7 +3,9 @@
 Patch release for the v02-03 development series (see the [v02-03 release notes](https://github.com/iLCSoft/iLCInstall/blob/master/doc/release_notes_ilcsoft_v02-03.md) for more details about this series).
 
 ## External software versions upgrade
-DD4hep 01-20-02 :arrow_right: 01-25-01
+- DD4hep 01-20-02 :arrow_right: 01-25-0
+- ROOT 6.24/06 :arrow_right: 6.28/04
+- Geant4 11.0.2 :arrow_right: 11.1.1
 
 ## New packages
 

--- a/ilcsoft/k4edm4hep2lcioconv.py
+++ b/ilcsoft/k4edm4hep2lcioconv.py
@@ -18,6 +18,14 @@ class k4edm4hep2lcioconv(BaseILC):
 
         self.reqmodules = ["edm4hep", "LCIO"]
 
+        self.reqfiles = [
+            [
+                "install/lib/libk4EDM4hep2LcioConv.so",
+                "install/lib64/libk4EDM4hep2LcioConv.so",
+            ],
+            ["install/bin/lcio2edm4hep"],
+        ]
+
     def init(self):
         """initialize k4edm4hep2lcioconv"""
         BaseILC.init(self)

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -254,7 +254,6 @@ ilcsoft.module("edm4hep").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
 
 ilcsoft.install( k4edm4hep2lcioconv( k4edm4hep2lcioconv_version ) )
 ilcsoft.module("k4edm4hep2lcioconv").envcmake["USE_EXTERNAL_CATCH2"] = "OFF"
-ilcsoft.module("k4edm4hep2lcioconv").envcmake["BUILD_TESTING"] = "OFF"  # See https://github.com/key4hep/k4EDM4hep2LcioConv/pull/24
 
 ilcsoft.install( aidaTT( aidaTT_version )) 
 ilcsoft.module("aidaTT").download.type="GitHub"

--- a/releases/HEAD/release-ilcsoft.cfg
+++ b/releases/HEAD/release-ilcsoft.cfg
@@ -254,6 +254,7 @@ ilcsoft.module("edm4hep").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
 
 ilcsoft.install( k4edm4hep2lcioconv( k4edm4hep2lcioconv_version ) )
 ilcsoft.module("k4edm4hep2lcioconv").envcmake["USE_EXTERNAL_CATCH2"] = "OFF"
+ilcsoft.module("k4edm4hep2lcioconv").envcmake["BUILD_TESTING"] = "OFF"  # See https://github.com/key4hep/k4EDM4hep2LcioConv/pull/24
 
 ilcsoft.install( aidaTT( aidaTT_version )) 
 ilcsoft.module("aidaTT").download.type="GitHub"

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -251,6 +251,7 @@ ilcsoft.module("edm4hep").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
 
 ilcsoft.install( k4edm4hep2lcioconv( k4edm4hep2lcioconv_version ) )
 ilcsoft.module("k4edm4hep2lcioconv").envcmake["USE_EXTERNAL_CATCH2"] = "OFF"
+ilcsoft.module("k4edm4hep2lcioconv").envcmake["BUILD_TESTING"] = "OFF"  # See https://github.com/key4hep/k4EDM4hep2LcioConv/pull/24
 
 ilcsoft.install( aidaTT( aidaTT_version )) 
 ilcsoft.module("aidaTT").download.type="GitHub"

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -249,6 +249,8 @@ ilcsoft.install( edm4hep( edm4hep_version ))
 ilcsoft.module("edm4hep").envcmake["BUILD_DDG4EDM4HEP"] = 'OFF'
 ilcsoft.module("edm4hep").envcmake["USE_EXTERNAL_CATCH2"] = 'OFF'
 
+ilcsoft.install( k4edm4hep2lcioconv( k4edm4hep2lcioconv_version ) )
+ilcsoft.module("k4edm4hep2lcioconv").envcmake["USE_EXTERNAL_CATCH2"] = "OFF"
 
 ilcsoft.install( aidaTT( aidaTT_version )) 
 ilcsoft.module("aidaTT").download.type="GitHub"

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -8,16 +8,16 @@
 ###########################################
 
 # --------- ilcsoft release version ------------------------------------------
-ilcsoft_release = 'v02-03-01'
+ilcsoft_release = "v02-03-02"
 # ----------------------------------------------------------------------------
 
 # which cxx standard to use
 cxx_standard = 17
 
-#===============================================================================
+# ===============================================================================
 # use a compiler that knows c++17, use e.g. scripts/use_gcc103_cvmfs_centos7.sh
 #
-'''
+"""
 # --- gcc from LCG_101
 source /cvmfs/sft.cern.ch/lcg/releases/gcc/10.3.0/x86_64-centos7/setup.sh
 
@@ -32,10 +32,9 @@ export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-e475b/x86_64-cen
 
 # --- use a suitable mysql (also LCG_101)
 export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.4.20-c0154/x86_64-centos7-gcc10-opt
-'''
+"""
 # before starting the installation
-#================================================================================
-
+# ================================================================================
 
 
 # --------- install dir ------------------------------------------------------
@@ -45,16 +44,16 @@ export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.4.20-c0154/x86_64-cent
 #
 
 if installPrefix is None:
-    ilcsoft_install_prefix = ilcsoft_afs_path[ arch ]
+    ilcsoft_install_prefix = ilcsoft_afs_path[arch]
 else:
     ilcsoft_install_prefix = installPrefix
 
 # ----------------------------------------------------------------------------
-#--- the ilcsoft_release is now automatically appended in release-ilcsoft.cfg
+# --- the ilcsoft_release is now automatically appended in release-ilcsoft.cfg
 #     but not in release-base.cfg !!
 
-#append_version_to_install_prefix = False
-#if(append_version_to_install_prefix):
+# append_version_to_install_prefix = False
+# if(append_version_to_install_prefix):
 #    ilcsoft_install_dir = os.path.join(ilcsoft_install_prefix , ilcsoft_release )
 
 # ----------------------------------------------------------------------------
@@ -73,9 +72,8 @@ ilcPath = ilcsoft_install_prefix
 # ----------------------------------------------------------------------------
 
 
-#--------------------------------------------------------------------------
-#ilcPatchPath = "/afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5/v01-15"
-
+# --------------------------------------------------------------------------
+# ilcPatchPath = "/afs/desy.de/project/ilcsoft/sw/x86_64_gcc41_sl5/v01-15"
 
 
 # ======================= PACKAGES WITH NO INSTALL SUPPORT ===================
@@ -87,10 +85,10 @@ ilcPath = ilcsoft_install_prefix
 # when using package manager like apt-get, yum or brew
 platfDefault = None
 
-if platform.system().lower().find('linux') >= 0:
-   platfDefault = '/usr'
-elif platform.system().lower().find('darwin') >= 0:
-   platfDefault = '/usr/local'
+if platform.system().lower().find("linux") >= 0:
+    platfDefault = "/usr"
+elif platform.system().lower().find("darwin") >= 0:
+    platfDefault = "/usr/local"
 
 # ----- mysql --------------------------------------------------------
 MySQL_version = "10.4.20"
@@ -98,7 +96,7 @@ MySQL_path = platfDefault
 
 # overwrite with a patch set in the environment
 my_mysql_path = os.getenv("MYSQL_DIR", default=None)
-if( my_mysql_path !=  None ):
+if my_mysql_path != None:
     MySQL_path = my_mysql_path
 
 # ----------------------------------------------------------------------------
@@ -111,12 +109,11 @@ if( my_mysql_path !=  None ):
 ##########################################################################################
 
 
-
 # ======================= PACKAGE VERSIONS ===================================
 
-Geant4_version =  "11.0.2"
+Geant4_version = "11.0.2"
 
-CLHEP_version =  "2.4.5.3"
+CLHEP_version = "2.4.5.3"
 
 ROOT_version = "6.24.06"
 
@@ -150,7 +147,7 @@ XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 # -------------------------------------------
 
-LCIO_version = "v02-19"
+LCIO_version = "v02-20"
 
 GEAR_version = "v01-09-01"
 
@@ -166,7 +163,7 @@ DDKalTest_version = "v01-07"
 
 MarlinTrk_version = "v02-09-01"
 
-MarlinTrkProcessors_version = "v02-12-02"
+MarlinTrkProcessors_version = "v02-12-03"
 
 Clupatra_version = "v01-03"
 
@@ -176,7 +173,7 @@ KiTrackMarlin_version = "v01-13-02"
 
 ForwardTracking_version = "v01-14-01"
 
-ConformalTracking_version = "v01-11"
+ConformalTracking_version = "v01-11-01"
 
 LICH_version = "v00-01"
 
@@ -184,9 +181,9 @@ GBL_version = "V02-02-01"
 
 LCCD_version = "v01-05-01"
 
-RAIDA_version = "v01-09"
+RAIDA_version = "v01-10"
 
-MarlinUtil_version = "v01-17"
+MarlinUtil_version = "v01-17-01"
 
 Marlin_version = "v01-19"
 
@@ -216,7 +213,7 @@ PandoraAnalysis_version = "v02-00-01"
 
 CEDViewer_version = "v01-19-01"
 
-Overlay_version = "v00-22-04"
+Overlay_version = "v00-23"
 
 PathFinder_version = "v00-06-01"
 
@@ -230,11 +227,11 @@ BBQ_version = "v00-01-04"
 
 Garlic_version = "v03-01"
 
-DD4hep_version = "v01-20-02"
+DD4hep_version = "v01-25-01"
 
-DD4hepExamples_version = "v01-20-02"
+DD4hepExamples_version = "v01-25-01"
 
-lcgeo_version = "v00-18"
+lcgeo_version = "v00-18-01"
 
 podio_version = "v00-16-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -235,7 +235,7 @@ lcgeo_version = "v00-18-01"
 
 podio_version = "v00-16-05"
 
-edm4hep_version = "v00-09"
+edm4hep_version = "v00-10"
 
 k4edm4hep2lcioconv_version = "v00-05"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -237,6 +237,6 @@ podio_version = "v00-16-05"
 
 edm4hep_version = "v00-09"
 
-k4edm4hep2lcioconv_version = "HEAD"  # TODO: tag
+k4edm4hep2lcioconv_version = "v00-05"
 
 Physsim_version = "v00-04-02"

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -113,7 +113,7 @@ if my_mysql_path != None:
 
 Geant4_version = "11.1.1"
 
-CLHEP_version = "2.4.5.3"
+CLHEP_version = "2.4.6.4"
 
 ROOT_version = "6.28.04"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -115,7 +115,7 @@ Geant4_version = "11.1.1"
 
 CLHEP_version = "2.4.5.3"
 
-ROOT_version = "6.24.06"
+ROOT_version = "6.28.04"
 
 GSL_version = "2.7"
 
@@ -135,7 +135,7 @@ Eigen_version = "3.4.0"
 
 CondDBMySQL_version = "CondDBMySQL_ILC-0-9-7"
 
-ILCUTIL_version = "v01-07"
+ILCUTIL_version = "v01-07-01"
 
 FastJet_version = "3.4.0"
 
@@ -181,7 +181,7 @@ GBL_version = "V02-02-01"
 
 LCCD_version = "v01-05-01"
 
-RAIDA_version = "v01-10"
+RAIDA_version = "v01-11"
 
 MarlinUtil_version = "v01-17-01"
 
@@ -191,11 +191,11 @@ MarlinDD4hep_version = "v00-06-02"
 
 DDMarlinPandora_version = "v00-12"
 
-MarlinReco_version = "v01-33-01"
+MarlinReco_version = "v01-34"
 
 FCalClusterer_version = "v01-00-03"
 
-ILDPerformance_version = "v01-11"
+ILDPerformance_version = "v01-12"
 
 # ILDConfig_version = "v02-03"
 
@@ -233,8 +233,10 @@ DD4hepExamples_version = "v01-25-01"
 
 lcgeo_version = "v00-18-01"
 
-podio_version = "v00-16-01"
+podio_version = "v00-16-05"
 
-edm4hep_version = "v00-07-02"
+edm4hep_version = "v00-09"
+
+k4edm4hep2lcioconv_version = "HEAD"  # TODO: tag
 
 Physsim_version = "v00-04-02"

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -111,7 +111,7 @@ if my_mysql_path != None:
 
 # ======================= PACKAGE VERSIONS ===================================
 
-Geant4_version = "11.0.2"
+Geant4_version = "11.1.1"
 
 CLHEP_version = "2.4.5.3"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add new package
  - k4EDM4hep2LcioConv v00-05 (LCIO to EDM4hep conversion)

- Update base package versions
  - DD4hep 01-25-01
  - ROOT 6.28/04
  - Geant4 11.1.1

- Update package versions to latest tags
    - MarlinReco v01-34
    - podio v00-16-05
    - EDM4hep v00-10
    - iLCUtil v01-07-01
    - LCIO v02-20
    - lcgeo (k4geo) v00-18-01
    - MarlinUtil v01-17-01
    - RAIDA v01-10
    - ConformalTracking v01-11-01
    - MarlinTrkProcessors v02-12-03
    - Overlay v00-23
    - ILDPerformance v01-12

ENDRELEASENOTES