### PR TITLE
Fix CMAKE_PREFIX_PATH for Geant4 > v11.1

### DIFF
--- a/ilcsoft/geant4.py
+++ b/ilcsoft/geant4.py
@@ -90,13 +90,17 @@ class Geant4(BaseILC):
             else:
                 self.download.url = "http://cern.ch/geant4-data/releases/geant4-v%s.tar.gz" % self.version
 
-        v = Version( self.version )
-        if( len(v)==2):
-            v = "%s.%s" % ( v[0], v[1] )
-        else:
-            v = "%s.%s.%s" % ( v[0], v[1], v[2] )
+        v = Version(self.version)
+        if v < "11.1":
+            if( len(v)==2):
+                v = "%s.%s" % ( v[0], v[1] )
+            else:
+                v = "%s.%s.%s" % ( v[0], v[1], v[2] )
 
-        self.cmakeconfig = self.installPath + "/lib/Geant4-" + v  + ";" + self.installPath + "/lib64/Geant4-" + v
+            self.cmakeconfig = self.installPath + "/lib/Geant4-" + v  + ";" + self.installPath + "/lib64/Geant4-" + v
+        else:
+            self.cmakeconfig = self.installPath + "/lib/cmake;" + self.installPath + "/lib64/cmake"
+
 
     def compile(self):
         """ compile Geant4 """


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that `CMAKE_PREFIX_PATH` points to the right place for Geant4 > v11.1 where it has been moved to a more standard location.

ENDRELEASENOTES