### PR TITLE
Remove unittests running on python 2.7

### DIFF
--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: ['2.7.x', '3.7']
+        py_version: ['3.7']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove workflow that requires a no longer supported python version. Fixes #167 

ENDRELEASENOTES