### PR TITLE
add ROOT_INCLUDE_PATH to base module

### DIFF
--- a/ilcsoft/baseilc.py
+++ b/ilcsoft/baseilc.py
@@ -87,7 +87,8 @@ class BaseILC:
             "CLASSPATH" : [],
             "LD_RUN_PATH" : [],
             "DT_RUN_PATH" : [],
-            "MARLIN_DLL" : []
+            "MARLIN_DLL" : [],
+            "ROOT_INCLUDE_PATH" : []
         }
 
 ## fg: this causes problems on (my) mac with Mojave ...


### PR DESCRIPTION

BEGINRELEASENOTES
- add ROOT_INCLUDE_PATH to base module
     - needed for podio.py (see: https://github.com/iLCSoft/iLCInstall/pull/168)

ENDRELEASENOTES