### PR TITLE
Some updates for key4hep and Marlin packages

### DIFF
--- a/examples/macbookfg/release-versions.py
+++ b/examples/macbookfg/release-versions.py
@@ -106,21 +106,12 @@ MySQL_path = "/usr/local"
 
 
 # ======================= PACKAGE VERSIONS ===================================
-##Geant4_version =  "10.06.p02"
-##CLHEP_version =  "2.4.1.3"  #"2.3.4.3"
-##ROOT_version = "6.22.02"
-##GSL_version = "2.6"   #"2.1" # "1.15"
-##Qt5_version = "v5.13.1"
-##CMake_version = "3.17.3" ##"3.15.2"   #"3.4.3" #"2.8.5"
-##SIO_version = "v00-00-03"
-Eigen_version = "3.3.7"
-##Boost_version = "1.71.0"
 
-Geant4_version =  "11.0.2"
+Geant4_version =  "11.1.1"
 
-CLHEP_version =  "2.4.5.3"
+CLHEP_version =  "2.4.6.4"
 
-ROOT_version = "6.26.06"
+ROOT_version = "6.28.04"
 
 GSL_version = "2.7"
 
@@ -134,7 +125,7 @@ SIO_version = "v00-01"
 
 Boost_version = "1.77.0"
 
-#Eigen_version = "3.4.0"
+Eigen_version = "3.4.0"
 
 # -------------------------------------------
 

--- a/ilcsoft/baseilc.py
+++ b/ilcsoft/baseilc.py
@@ -757,8 +757,9 @@ class BaseILC:
         elif self.download.type[:6] == "GitHub":
             if self.version =="HEAD" or self.version =="dev" or self.version =="devel" or self.version =="master" or self.download.branch:
                 #clone the whole repo into the directory
-                branch = 'master' if self.download.branch is None else self.download.branch
-                cmd="git clone -b %s https://github.com/%s/%s.git %s" % (branch, self.download.gituser, self.download.gitrepo, self.version)
+                branch = '' if self.download.branch is None else '-b ' + self.download.branch
+
+                cmd="git clone %s https://github.com/%s/%s.git %s" % (branch, self.download.gituser, self.download.gitrepo, self.version)
                 print("Executing command:",cmd)
                 if os_system( cmd ) != 0:
                     self.abort( "Problems occurred during execution of " + cmd + " [!!ERROR!!]")

--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -403,63 +403,7 @@ class ILCSoft:
         print("\n" + 30*'*' + " Starting ILC Software installation process " + 30*'*' + "\n")
         # write CMake Environment to file ILCSoft.cmake
         self.writeCMakeEnv()
-
-        # write init_ilcsoft.sh
-        checked=[]
-        f = open(self.installPath + "/init_ilcsoft.sh", 'w')
-        
-        f.write( 'export ILCSOFT='+self.installPath  + os.linesep  )
-        
-        #------- prepend the pathes for the compiler and python used in this installation -------
-
-        compiler = self.env["CXX"]
-        status, cxx_path = getstatusoutput( "which "+compiler )
-        cxx_path =  os.path.dirname( os.path.dirname( cxx_path ) ) # remove '/bin/g++'
-
-        status, py_path = getstatusoutput( "which python" )
-        py_path =  os.path.dirname( os.path.dirname( py_path ) ) # remove '/bin/python'
-
-        f.write( os.linesep + '# -------------------------------------------------------------------- ---' + os.linesep )
-        f.write( os.linesep + '# ---  Use the same compiler and python as used for the installation   ---' + os.linesep )
-        f.write( os.linesep + '# -------------------------------------------------------------------- ---' + os.linesep )
-        # On cvmfs the gcc/llvm compilers are setup using the setup.sh file
-        # source also other important scripts. Adding the compiler to LD_LIBRARY_PATH and PATH
-        # is not enough. The setup.sh file is also setting up paths to binutils and other important variables
-        if os.path.exists( cxx_path + "/setup.sh" ):
-            f.write( '. ' + cxx_path + '/setup.sh' + os.linesep + os.linesep  )
-        else:
-            f.write( 'export PATH='+cxx_path+'/bin:${PATH}' + os.linesep  )
-            f.write( 'export LD_LIBRARY_PATH='+cxx_path+'/lib64:'+ cxx_path+'/lib:${LD_LIBRARY_PATH}' + os.linesep  + os.linesep )
-        
-        # export Python in PATH and LD_LIBRARY_PATH
-        f.write( 'export PATH='+py_path+'/bin:${PATH}' + os.linesep  )
-        f.write( 'export LD_LIBRARY_PATH='+py_path+'/lib:${LD_LIBRARY_PATH}' + os.linesep  + os.linesep )
-        # copy the PYTHONPATH verbatim from the build setup if it is set
-        python_path = os.getenv('PYTHONPATH')
-        if python_path:
-            f.write('export PYTHONPATH=' + python_path + os.linesep + os.linesep )
-
-        f.write( 'export CXX=' + compiler + os.linesep )
-        ccompiler = self.env["CC"]
-        f.write( 'export CC=' + ccompiler + os.linesep )
-
-        # set GIT_EXEC_PATH inherited from the setup.sh
-        if os.environ.get("GIT_EXEC_PATH"):
-            f.write('export GIT_EXEC_PATH=%s' % os.environ.get("GIT_EXEC_PATH"))
-
-        #----------------------------------------------------------------------------------------
-
-
-        for mod in self.modules:
-            mod.writeEnv(f, checked)
-        if self.os.type == "Darwin":
-            f.write( os.linesep + '# --- set DYLD_LIBRARY_PATH to LD_LIBRARY_PATH for MAC compatibility ---' + os.linesep )
-            f.write( 'export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DYLD_LIBRARY_PATH' + os.linesep + os.linesep )
-        if ( self.os.ver.find("cientific") and self.release_number == '6'):
-            f.write( os.linesep + '# ---  Workaraund for OpenGl bug on SL6  ---' + os.linesep )
-            f.write( 'export LIBGL_ALWAYS_INDIRECT=1' + os.linesep  )
-
-
+        self.writeInit()
         print("\n" + 30*'*' + " Creating symlinks " + 30*'*' + "\n")
         for mod in self.modules:
             mod.createLink()
@@ -614,3 +558,4 @@ class ILCSoft:
         if ( self.os.ver.find("cientific") and self.release_number == '6'):
             f.write( os.linesep + '# ---  Workaraund for OpenGl bug on SL6  ---' + os.linesep )
             f.write( 'export LIBGL_ALWAYS_INDIRECT=1' + os.linesep  )
+        f.close()

--- a/ilcsoft/ilcsoft.py
+++ b/ilcsoft/ilcsoft.py
@@ -515,6 +515,7 @@ class ILCSoft:
         for mod in self.modules:
             os_system( "echo '%s:%s' >> %s" % (mod.alias,mod.version,depsfile) )
 
+        self.writeInit()
         print("\n" + 30*'*' + " Finished installation " + 30*'*' + "\n")
 
     def summary(self):
@@ -557,3 +558,59 @@ class ILCSoft:
                 mod.showDependencies()
 
         print("};")
+
+    def writeInit(self):
+        """write init_ilcsoft.sh"""
+        checked=[]
+        f = open(self.installPath + "/init_ilcsoft.sh", 'w')
+        
+        f.write( 'export ILCSOFT='+self.installPath  + os.linesep  )
+        
+        #------- prepend the pathes for the compiler and python used in this installation -------
+
+        compiler = self.env["CXX"]
+        status, cxx_path = getstatusoutput( "which "+compiler )
+        cxx_path =  os.path.dirname( os.path.dirname( cxx_path ) ) # remove '/bin/g++'
+
+        status, py_path = getstatusoutput( "which python" )
+        py_path =  os.path.dirname( os.path.dirname( py_path ) ) # remove '/bin/python'
+
+        f.write( os.linesep + '# -------------------------------------------------------------------- ---' + os.linesep )
+        f.write( os.linesep + '# ---  Use the same compiler and python as used for the installation   ---' + os.linesep )
+        f.write( os.linesep + '# -------------------------------------------------------------------- ---' + os.linesep )
+        # On cvmfs the gcc/llvm compilers are setup using the setup.sh file
+        # source also other important scripts. Adding the compiler to LD_LIBRARY_PATH and PATH
+        # is not enough. The setup.sh file is also setting up paths to binutils and other important variables
+        if os.path.exists( cxx_path + "/setup.sh" ):
+            f.write( '. ' + cxx_path + '/setup.sh' + os.linesep + os.linesep  )
+        else:
+            f.write( 'export PATH='+cxx_path+'/bin:${PATH}' + os.linesep  )
+            f.write( 'export LD_LIBRARY_PATH='+cxx_path+'/lib64:'+ cxx_path+'/lib:${LD_LIBRARY_PATH}' + os.linesep  + os.linesep )
+        
+        # export Python in PATH and LD_LIBRARY_PATH
+        f.write( 'export PATH='+py_path+'/bin:${PATH}' + os.linesep  )
+        f.write( 'export LD_LIBRARY_PATH='+py_path+'/lib:${LD_LIBRARY_PATH}' + os.linesep  + os.linesep )
+        # copy the PYTHONPATH verbatim from the build setup if it is set
+        python_path = os.getenv('PYTHONPATH')
+        if python_path:
+            f.write('export PYTHONPATH=' + python_path + os.linesep + os.linesep )
+
+        f.write( 'export CXX=' + compiler + os.linesep )
+        ccompiler = self.env["CC"]
+        f.write( 'export CC=' + ccompiler + os.linesep )
+
+        # set GIT_EXEC_PATH inherited from the setup.sh
+        if os.environ.get("GIT_EXEC_PATH"):
+            f.write('export GIT_EXEC_PATH=%s' % os.environ.get("GIT_EXEC_PATH"))
+
+        #----------------------------------------------------------------------------------------
+
+
+        for mod in self.modules:
+            mod.writeEnv(f, checked)
+        if self.os.type == "Darwin":
+            f.write( os.linesep + '# --- set DYLD_LIBRARY_PATH to LD_LIBRARY_PATH for MAC compatibility ---' + os.linesep )
+            f.write( 'export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DYLD_LIBRARY_PATH' + os.linesep + os.linesep )
+        if ( self.os.ver.find("cientific") and self.release_number == '6'):
+            f.write( os.linesep + '# ---  Workaraund for OpenGl bug on SL6  ---' + os.linesep )
+            f.write( 'export LIBGL_ALWAYS_INDIRECT=1' + os.linesep  )

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -30,7 +30,7 @@ class MarlinPKG(BaseILC):
     
     def __init__(self, name, userInput):
         BaseILC.__init__(self, userInput, name, name)
-        self.reqfiles = [ [ str("lib/lib" + name + ".a"), str("lib/lib" + name + ".so"), str("lib/lib" + name + ".dylib") ] ]
+        self.reqfiles = [ [ folder + "lib" + name + ext for ext in ('.so', '.a', '.dylib') for folder in ('lib/', 'lib64/') ] ]
         self.reqmodules=[ 'LCIO', 'Marlin' ]
 
         self.download.gitrepo = name

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -64,8 +64,10 @@ class MarlinPKG(BaseILC):
         if( self.name != "MarlinUtil" and self.name != "PandoraPFANew" ):
             for libdir in ("/lib/", "/lib64/"):
                 libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
+                print("MarlinDLL: looking for ", libname)
                 if os.path.exists(libname):
+                    print("MarlinDLL: Found ", libname)
                     self.parent.module('Marlin').envpath["MARLIN_DLL"].append(libname)
                     break
-                else:
-                    print( "ERROR: Marlin library not added to Marlin_DLL: ", libname )
+            else:
+                print("Error: did not find any library for the MarlinDLL", self.name)

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -57,11 +57,9 @@ class MarlinPKG(BaseILC):
         if( os_system( "make install" ) != 0 ):
             self.abort( "failed to install!!" )
 
-    def postCheckDeps(self):
-        BaseILC.postCheckDeps(self)
-
-        # fill MARLIN_DLL
-        if( self.name != "MarlinUtil" and self.name != "PandoraPFANew" ):
+    def checkInstall(self, abort=True):
+        BaseILC.checkInstall(self)
+        if self.name not in ("MarlinUtil", "PandoraPFANew", "Physsim", "LCFIVertex"):
             for libdir in ("/lib/", "/lib64/"):
                 libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
                 print("MarlinDLL: looking for ", libname)
@@ -71,3 +69,5 @@ class MarlinPKG(BaseILC):
                     break
             else:
                 print("Error: did not find any library for the MarlinDLL", self.name)
+                return False
+        return True

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -67,3 +67,5 @@ class MarlinPKG(BaseILC):
                 if os.path.exists(libname):
                     self.parent.module('Marlin').envpath["MARLIN_DLL"].append(libname)
                     break
+                else:
+                    print( "ERROR: Marlin library not added to Marlin_DLL: ", libname )


### PR DESCRIPTION
BEGINRELEASENOTES
- some fixes to keep up w/ changes in key4hep packages
      -  allow HEAD branch to be called main
      - patch lcgeo install to work w/ latest k4geo
- Allow Marlin packages to be installed into `lib64` or `lib` and make sure that `MARLIN_DLL` is populated properly.
- update versions of externals in example macbookfg

ENDRELEASENOTES