### PR TITLE
iLCSoft v02-03-04 release on EL/Alma9

### DIFF
--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -86,7 +86,13 @@ None
 * 2024-08-22 jmcarcell ([PR#56](https://github.com/iLCSoft/Marlin/pull/56))
   - Change LCIO_LIBRARIES to LCIO::lcio
 
-### MarlinReco v01-36-01 (merged notes from two tags)
+### MarlinReco v01-36-02 (merged notes from several tags)
+
+* 2025-02-20 Bohdan Dudar ([PR#146](https://github.com/iLCSoft/MarlinReco/pull/146))
+  - Fix a segmentation fault in RecoMCTruthLinker when an MCParticle is not found in the internal map (see [#125](https://github.com/iLCSoft/MarlinReco/issues/125))
+
+* 2024-10-01 Bohdan Dudar ([PR#142](https://github.com/iLCSoft/MarlinReco/pull/142))
+  - Fix `mismateched-new-delete` warning uncovered by gcc14 (see [#140](https://github.com/iLCSoft/MarlinReco/issues/140))
 
 * 2024-09-09 jmcarcell ([PR#139](https://github.com/iLCSoft/MarlinReco/pull/139))
   - Add a missing `#include <algorithm>`
@@ -126,7 +132,10 @@ None
 * 2024-04-16 NAKAJIMA Jurina ([PR#131](https://github.com/iLCSoft/MarlinReco/pull/131))
   - Fixed PDG code for kinks identifies as antiSigma+
 
-### MarlinUtil v01-18-01 (merged notes from two tags)
+### MarlinUtil v01-18-02 (merged notes from two tags)
+
+* 2025-03-31 Thomas Madlener ([PR#49](https://github.com/iLCSoft/MarlinUtil/pull/49))
+  - Make sure to fetch a Catch2 version that can actually be built with the required C++ standard.
 
 * 2024-08-26 tmadlener ([PR#47](https://github.com/iLCSoft/MarlinUtil/pull/47))
   - Fix a potential indexing issue in `WeightedPoints3D`
@@ -344,7 +353,11 @@ None
   - Clean up unused variables
 
 
-### DDMarlinPandora v00-12-02
+### DDMarlinPandora v00-13 (merged from several tags)
+
+* 2025-03-05 Archil Durglishvili ([PR#31](https://github.com/iLCSoft/DDMarlinPandora/pull/31))
+  - The "DetectorName" parameter is added to the DDPandoraPFANewProcessor which allows to setup the DDGeometryCreator, DDCaloHitCreator and DDTrackCreator for the ALLEGRO detector;
+  - Three new classes are created that are specific for the ALLEGRO detector: DDGeometryCreatorALLEGRO, DDCaloHitCreatorALLEGRO and DDTrackCreatorALLEGRO.
 
 * 2024-08-28 tmadlener ([PR#30](https://github.com/iLCSoft/DDMarlinPandora/pull/30))
   - Remove the no longer supported CentOS7 builds from the Key4hep based CI workflows
@@ -353,7 +366,10 @@ None
   - Make it possible to register ECAL energy corrections with Pandora similar to what is possible for the HCAL
 
 
-### MarlinTrkProcessors v02-12-06
+### MarlinTrkProcessors v02-12-07 (release notes from several tags)
+
+* 2025-03-21 jmcarcell ([PR#73](https://github.com/iLCSoft/MarlinTrkProcessors/pull/73))
+  - Set the subdetectorHitNumbers in ClonesAndSplitTracksFinder that was not being set (defaulted to 0) when `mergeSplitTracks` is false.
 
 * 2024-08-28 Victor Schwan ([PR#72](https://github.com/iLCSoft/MarlinTrkProcessors/pull/72))
   - Remove the hardcoded (ILD) detector names from the FullLDC tracking to allow its usage with the `v11` model of ILD.
@@ -390,7 +406,25 @@ None
   - Fix the problem: the system GSL may be picked. See details in https://github.com/key4hep/k4-spack/issues/77
 
 
-### GEAR v01-09-03 (merged notes from several tags)
+### GEAR v01-09-05 (merged notes from several tags)
+
+* 2025-03-31 Thomas Madlener ([PR#21](https://github.com/iLCSoft/GEAR/pull/21))
+  - Make sure that all libraries go the the same place during installation.
+
+* 2025-03-31 Thomas Madlener ([PR#20](https://github.com/iLCSoft/GEAR/pull/20))
+  - Update the Key4hep build action to the latest version to include nightlies on Ubuntu24
+
+* 2025-03-31 jmcarcell ([PR#19](https://github.com/iLCSoft/GEAR/pull/19))
+  - Add LANGUAGES CXX to the top level CMakeLists.txt to disable checks for a C compiler
+
+* 2025-03-31 jmcarcell ([PR#18](https://github.com/iLCSoft/GEAR/pull/18))
+  - Bump the minimum version of CMake to 3.5, to be able to compile with CMake 4.0
+
+* 2025-03-10 scott snyder ([PR#17](https://github.com/iLCSoft/GEAR/pull/17))
+  - Fix a few compiler warning.
+
+* 2025-03-10 sss ([PR#16](https://github.com/iLCSoft/GEAR/pull/16))
+  - Fix apparent off-by-one error in TPCParametersImpl::getNearestPad.
 
 * 2025-01-13 Thomas Madlener ([PR#15](https://github.com/iLCSoft/GEAR/pull/15))
   - Switch to central Key4hep CI build workflows and remove clicdp nightlies based ones

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -9,7 +9,7 @@ This patch release comes with several fundamental updates:
 - Python version updated from 3.9 to 3.11
 
 ## External software versions upgrade
-- ROOT 6.30/04 :arrow_right: 6.32.10
+- ROOT 6.30/04 :arrow_right: 6.32.12
 - DD4hep 01-28 :arrow_right: 01-31
 - Geant4 11.2.1 :arrow_right: 11.3.1
 - CMake 3.28.3 :arrow_right: 3.31.6
@@ -24,8 +24,12 @@ None
 
 ## Packages changed wrt. v02-03-03
 
-### LCIO v02-22-04 (merged notes for several tags)
+### LCIO v02-22-05 (merged notes for several tags)
 
+* 2025-02-10 Nazar Bartosik ([PR#202](https://github.com/iLCSoft/LCIO/pull/202))
+  - Merge the remaining changes that were made to the muon collider fork
+    - Make the `anajob.py` example python3 compatible (and remove python2 support) and install it as `anajob.py` executable if `BUILD_ROOTDICT` is enabled.
+    
 * 2025-02-03 Thomas Madlener ([PR#201](https://github.com/iLCSoft/LCIO/pull/201))
   - Make it possible to create empty subset collections during patching
     - Appending a **`*`** (star) to the collection type name (no spaces) will make this collection an empty subset collection if it is not already present.

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -9,10 +9,10 @@ This patch release comes with several fundamental updates:
 - Python version updated from 3.9 to 3.11
 
 ## External software versions upgrade
-- ROOT 6.30/04 :arrow_right: 6.32/06
+- ROOT 6.30/04 :arrow_right: 6.32/08
 - DD4hep 01-28 :arrow_right: 01-30
 - Geant4 11.2.1 :arrow_right: 11.2.2
-- CMake 3.28.3 :arrow_right: 3.31.0
+- CMake 3.28.3 :arrow_right: 3.30.5
 - boost 1.84.0 :arrow_right: 1.86.0
 - FastJet 3.4.2 :arrow_right: 3.4.3
 - FastJet Contrib 1.054 :arrow_right: 1.056
@@ -412,3 +412,5 @@ None
 * 2024-08-22 tmadlener ([PR#4](https://github.com/iLCSoft/KiTrack/pull/4))
   - Move CI to github actions and remove travis-ci config
   - Fix c++ warnings and enable `-Werror` for CI
+
+### PandoraPFANew v04-11-01

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -1,0 +1,414 @@
+# iLCSoft v02-03-04
+
+Patch release for the v02-03 development series (see the [v02-03 release notes](https://github.com/iLCSoft/iLCInstall/blob/master/doc/release_notes_ilcsoft_v02-03.md) for more details about this series).
+
+This patch release comes with several fundamental updates:
+- OS updated from CentOS7 to EL9
+- Compiler updated from gcc10.3 to gcc13.1
+- The c++ standard has been updated to c++20
+- Python version updated from 3.9 to 3.11
+
+## External software versions upgrade
+- ROOT 6.30/04 :arrow_right: 6.32/06
+- DD4hep 01-28 :arrow_right: 01-30
+- Geant4 11.2.1 :arrow_right: 11.2.2
+- CMake 3.28.3 :arrow_right: 3.31.0
+- boost 1.84.0 :arrow_right: 1.86.0
+- FastJet 3.4.2 :arrow_right: 3.4.3
+- FastJet Contrib 1.054 :arrow_right: 1.056
+- Qt 5.13.1 :arrow_right: 5.15.15
+
+# New packages
+
+None
+
+## Packages changed wrt. v02-03-03
+
+### LCIO v02-22-02 (merged notes for several tags)
+
+* 2024-09-05 tmadlener ([PR#193](https://github.com/iLCSoft/LCIO/pull/193))
+  - Add functionality to `CheckCollections` that makes it possible to add missing ParticleID algorithms to ReconstructedParticle collections
+    - This makes it possible to make very consistent event contents that are necessary for conversion to EDM4hep
+
+* 2024-08-01 tmadlener ([PR#196](https://github.com/iLCSoft/LCIO/pull/196))
+  - Run Key4hep CI workflows on OSs that are still supported
+
+* 2024-08-01 tmadlener ([PR#195](https://github.com/iLCSoft/LCIO/pull/195))
+  - Add a basic `.gitignore` file to avoid accidentally comitting configured / generated files
+
+* 2024-08-01 Thomas Madlener ([PR#194](https://github.com/iLCSoft/LCIO/pull/194))
+  - Make sure to require a version of SIO that is consistent with what we would use to build an internal version.
+  
+* 2024-06-24 jmcarcell ([PR#192](https://github.com/iLCSoft/LCIO/pull/192))
+  - Fix possibly wrong behavior with `std::remove_if` with a `erase - remove` idiom
+
+* 2024-06-24 Wouter Deconinck ([PR#191](https://github.com/iLCSoft/LCIO/pull/191))
+  - fix: parentheses in SIOTrack.java
+
+* 2024-06-07 tmadlener ([PR#189](https://github.com/iLCSoft/LCIO/pull/189))
+  - Remove mentions of the removed F77 API (see [#161](https://github.com/iLCSoft/LCIO/pull/161)) from the documentation
+
+* 2024-06-06 tmadlener ([PR#190](https://github.com/iLCSoft/LCIO/pull/190))
+  - Remove the no longer used settings for the 32bit compatibility mode
+
+* 2024-06-06 Nazar Bartosik ([PR#147](https://github.com/iLCSoft/LCIO/pull/147))
+  - Add `Nholes` and and `subdetectorHoleNumbers` to the `Track` for keeping track of missing hits in a Track.
+
+* 2024-05-08 Bohdan Dudar ([PR#170](https://github.com/iLCSoft/LCIO/pull/170))
+  - Added new utility `dumpmctree` to draw the MC table of the event stored in the slcio file as the graphviz tree diagram, which represents parent-daughter relations visually in a easier way.
+    - `dumpmctree` is a small wrapper script around the actual `dumpmctree-dot` executable. The latter produces a `.dot` file which is then transformed into an `.svg` file via the wrapper script and the `dot` executable.
+    - The script relies on `dot` & `xdg-open` to be available on your system.
+
+* 2024-04-15 tmadlener ([PR#188](https://github.com/iLCSoft/LCIO/pull/188))
+  - Make the `PIDHandler` usable as `const` object by marking getters that do not mutate internal state as `const`
+
+### Marlin v01-19-03
+
+* 2024-08-22 tmadlener ([PR#59](https://github.com/iLCSoft/Marlin/pull/59))
+  - Make sure the `LCIO::lcio` target is also defined in packages consuming Marlin (necessary after #56)
+
+* 2024-08-22 tmadlener ([PR#58](https://github.com/iLCSoft/Marlin/pull/58))
+  - Make sure that all names that are used by `EventModifier` are forward declared
+  - Add missing include to make `EventModifier` usable without having to re-order includes
+  - Update the key4hep based github action workflows to use supported OSs
+
+* 2024-08-22 jmcarcell ([PR#56](https://github.com/iLCSoft/Marlin/pull/56))
+  - Change LCIO_LIBRARIES to LCIO::lcio
+
+### MarlinReco v01-36-01 (merged notes from two tags)
+
+* 2024-09-09 jmcarcell ([PR#139](https://github.com/iLCSoft/MarlinReco/pull/139))
+  - Add a missing `#include <algorithm>`
+
+* 2024-09-03 Thomas Madlener ([PR#137](https://github.com/iLCSoft/MarlinReco/pull/137))
+  - Remove CentOS7 from the Key4hep CI workflows
+
+* 2024-07-30 Ulrich Einhaus ([PR#136](https://github.com/iLCSoft/MarlinReco/pull/136))
+  Bug: PFOs were ignored if their MC PDG was not among signal or background PDGs. This is of minor effect, since by default all detector-stable charged particles are considered signal or background, but could lead to MC info leaking into reconstructed values in case of unintended usage.
+  Solution: This effect now requires training mode to be ON, which is exclusive with inference mode.
+
+* 2024-06-24 tmadlener ([PR#135](https://github.com/iLCSoft/MarlinReco/pull/135))
+  - Add a `ReconstructedParticleParticleIDFilterProcessor` that allows to filter `ParticleID` objects from existing `ReconstructedParticle`s.
+
+* 2024-06-24 tmadlener ([PR#132](https://github.com/iLCSoft/MarlinReco/pull/132))
+  - Make the `TrueJet` processor use the `PIDHandler` to set the `ParticleIDs` for the different objects it creates. This sets the necessary metadata that is required, e.g. for the conversion to EDM4hep.
+
+* 2024-06-19 Carl Mikael Berggren ([PR#134](https://github.com/iLCSoft/MarlinReco/pull/134))
+  Reduce the size of the ParticleID vector for the final fermion-antifermion pair, since
+  
+  for this case, there can only be one pair. This to avoid cluttering of empty collections after transition to the EDM4HEP world. At the same time, the documentation and example steerings in the examples subdirectory have been updated. mainly for the move of TrueJet_Parser from here to MarlinUtil, but also spell-checking etc.
+
+* 2024-06-10 Ulrich Einhaus ([PR#133](https://github.com/iLCSoft/MarlinReco/pull/133))
+  - This adds the WWCategorisationProcessor to MarlinReco
+  - It categorises each event by its WW decays channels. It provides a true category (only meaningful for true WW events) as well as two levels of reconstructed category. They are stored as event parameters.
+  - This may serve as common coherent categorisation for any analyses using WW events.
+
+* 2024-05-07 Bohdan Dudar ([PR#99](https://github.com/iLCSoft/MarlinReco/pull/99))
+  - Fix all compiler warnings in MarlinReco, including
+    - A lot of shadowed variables
+    - A lot of unused parameters / variables
+    - A few deprecations
+    - A genuine use-after-free bug
+    - A few others
+  - Make at least one CI workflow use `-Werror` to make it harder to (re-)introduce new warnings
+
+* 2024-04-16 NAKAJIMA Jurina ([PR#131](https://github.com/iLCSoft/MarlinReco/pull/131))
+  - Fixed PDG code for kinks identifies as antiSigma+
+
+### MarlinUtil v01-18-01 (merged notes from two tags)
+
+* 2024-08-26 tmadlener ([PR#47](https://github.com/iLCSoft/MarlinUtil/pull/47))
+  - Fix a potential indexing issue in `WeightedPoints3D`
+  - Remove no longer supported CentOS7 from Key4hep workflows
+
+* 2024-06-20 tmadlener ([PR#46](https://github.com/iLCSoft/MarlinUtil/pull/46))
+  - Prefix currently unprefixed member variables of the `TrueJet_Parser` with an `m_` prefix.
+
+* 2024-06-19 Ulrich Einhaus ([PR#45](https://github.com/iLCSoft/MarlinUtil/pull/45))
+  - Adds SelectNthEventsProcessor.
+  - This sets its own processor ReturnValue to true or false, depending on chosen parameters, which can be used in the Marlin steering file to use a particular sub-set of a sample.
+  - Via the InvertSelection parameter this can be easily inverted, which is convenient for training vs. inference of ML models.
+
+* 2024-04-29 tmadlener ([PR#44](https://github.com/iLCSoft/MarlinUtil/pull/44))
+  - Update CI to use latest clicdp nightlies and central key4hep build workflows
+  - Make Catch2 discovery a bit more robust and easier to use
+
+* 2024-04-29 Bohdan Dudar ([PR#43](https://github.com/iLCSoft/MarlinUtil/pull/43))
+  - Avoid the TColor warning when retrieving existing colours.
+
+### k4geo (lcgeo) v00-21-00
+
+* 2024-10-02 mahmoudali2 ([PR#401](https://github.com/key4hep/k4geo/pull/401))
+  - IDEA_o1_v03: Moving IDEA muon system starting point in both barrel (rmin) and endcap (z-offset) 30 mm, backwards to avoid overlapping with Dual readout calorimeter.
+    - The change including also updating chamber names to distinguish between muon chambers and pre shower chamber, since they are using the same uURWELL chamber.
+    - Change dimensions of solenoid/endplate and move the pre-shower to avoid overlaps with dual readout calorimeter
+
+* 2024-10-02 michaela mlynarikova ([PR#395](https://github.com/key4hep/k4geo/pull/395))
+  - fix printout messages in HCal Tile barrel and Endcap three parts detector builder
+
+* 2024-10-01 tmadlener ([PR#398](https://github.com/key4hep/k4geo/pull/398))
+  - Switch the `pre-commit` action to run in a Key4hep environment
+  - Add `ruff` formatting to `pre-commit`
+  - Fix a few python2 style `print` statements
+  - Fix format of all python files
+
+* 2024-10-01 mahmoudali2 ([PR#397](https://github.com/key4hep/k4geo/pull/397))
+  - Generalizing the muon system builder to adopt pre-shower description, the changes include:
+       - Making the variable names more general, not specific only for muon system.
+       - Changing the detector side's volume thicknesses in case there is only one chambers row in the side (like the pre-shower case), and it's in general it is the case for any -almost- circular shape for the detector. 
+       - Disallowing the overlap rotation in case of single chamber side.
+  - Overall, the changes make the builder more general to adopt different cases with different structures (polyhedron & cylinder of chambers).
+
+* 2024-10-01 Thomas Madlener ([PR#394](https://github.com/key4hep/k4geo/pull/394))
+  - Improve readability of README for FCCee MDI
+
+* 2024-09-25 armin.ilg ([PR#396](https://github.com/key4hep/k4geo/pull/396))
+  - No more warnings in silicon wrapper
+  - Improvements in vertex builder printouts
+  - Adding all materials of beam pipe also to material_plots_2D.py, as without having the beam pipe enabled, the vertex material budget estimation will fail.
+  - Changed paths to .stl files in vertex to use https://fccsw.web.cern.ch/fccsw/filesForSimDigiReco/IDEA/IDEA_o1_v03/STL_FILES/ (still commented out due to overlaps)
+
+* 2024-09-19 Armin Fehr ([PR#363](https://github.com/key4hep/k4geo/pull/363))
+  - Update of IDEA vertex, with the ability to use the ultra-light vertex concept in-situ.
+  - No overlaps in all of vertex and silicon wrapper (not including the DDCAD imported vertex support and cooling cones yet), more performant silicon wrapper (only silicon wrapper barrel sensors are simplified)
+
+* 2024-09-18 Erich Varnes ([PR#379](https://github.com/key4hep/k4geo/pull/379))
+  * ECalEndcap_Turbine_o1_v01_geo: Fix issues with printout (to allow verbosity to be controlled from run script).  
+  * Add ECalEndcap_Turbine_o1_v02_geo of the "turbine" endcap geometry: which allows for more flexibility than v01 (for example, one can set different blade angles for the three wheels in v02).  As v02 is still a work in progress, the default xml points to v01.
+
+* 2024-09-16 JEANS Daniel Thomelin Dietrich ([PR#388](https://github.com/key4hep/k4geo/pull/388))
+  - For ILD models only: apply the same step limits as defined for the tracker ("Tracker_limits", currently 5mm) inside the beampipe volume and MDI region. This is important for tracking of low momentum particles  (eg beamstrahlung pairs) especially in non-uniform fields. Should have no noticeable effect in other situations.
+
+* 2024-09-12 Andre Sailer ([PR#391](https://github.com/key4hep/k4geo/pull/391))
+  - CLD_o2_v07: change LumiCal envelopes from boolean of boolean to assembly, fixes #306, speeds up overlap check (of LumiCal only) with /geometry/test/resolution 300000 down to 13s instead of 3m10s
+
+* 2024-09-10 jmcarcell ([PR#387](https://github.com/key4hep/k4geo/pull/387))
+  - Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.
+
+* 2024-09-03 jmcarcell ([PR#386](https://github.com/key4hep/k4geo/pull/386))
+  - Do not link against podio and EDM4hep dictionaries. Introduced in https://github.com/key4hep/k4geo/pull/346, I think it's never necessary to link to the dictionaries.
+
+* 2024-09-02 Andre Sailer ([PR#385](https://github.com/key4hep/k4geo/pull/385))
+  - FieldMapXYZ, FieldMapBrBz: adapt to variable rename from DD4hep, fix "OverlayedField   ERROR add: Attempt to add an unknown field type.", fixes #384
+
+* 2024-08-29 Andre Sailer ([PR#383](https://github.com/key4hep/k4geo/pull/383))
+  - CLD_o2_v07: fix overlaps related to the LumiCal, slight correction in the position of the envelopes and passive material. Fixes #376
+
+* 2024-08-28 Leonhard Reichenbach ([PR#369](https://github.com/key4hep/k4geo/pull/369))
+  - Added TrackerBarrel_o1_v06 using a stave assembly instead of directly placing the sensors into the layers
+  - Added CLD_o2_v07 using the new TrackerBarrel_o1_v06
+
+* 2024-08-28 michaela mlynarikova ([PR#350](https://github.com/key4hep/k4geo/pull/350))
+  - added new HCalEndcaps_ThreeParts_TileCal_v02.xml: migrated to use FCCSWGridPhiTheta_k4geo; fixed radial dimensions, so the outer radius of all three parts is the same; renamed nModules to nsegments for number of layers in the second cylinder; uses geometry CaloThreePartsEndcap_o1_v02
+  
+  - added new HCalBarrel_TileCal_v02.xml which uses geometry HCalTileBarrel_o1_v01
+  
+  - updated ALLEGRO_o1_v03.xml to include HCalBarrel_TileCal_v02.xml and HCalEndcaps_ThreeParts_TileCal_v02.xml
+  
+  - added new HCalThreePartsEndcap_o1_v02_geo.cpp: added extension to store the radii of each radial layer as well as dimensions of cells. These will be used by the CellPositionsHCalPhiThetaSegTool to calculate the radii of each layer. Improved code readability and variables naming 
+  
+  - updated HCalTileBarrel_o1_v01_geo.cpp: added extension to store the radii of each radial layer as well as dimensions of cells. These will be used by the CellPositionsHCalPhiThetaSegTool to calculate the radii of each layer. Improved code readability and variables naming
+
+* 2024-08-22 Victor Schwan ([PR#378](https://github.com/key4hep/k4geo/pull/378))
+  - 2nd SIT barrel layer ID was corrected for `ILD_l5_v11`; the error stemmed from out-commenting 2nd out of 3 layers without adjusting hard-coded layer IDs
+
+* 2024-08-20 BrieucF ([PR#372](https://github.com/key4hep/k4geo/pull/372))
+  - [FCCeeMDI] Use absolute path to import CAD files
+
+* 2024-08-09 jmcarcell ([PR#374](https://github.com/key4hep/k4geo/pull/374))
+  - Fix a few compiler warnings
+
+* 2024-08-09 Erich Varnes ([PR#373](https://github.com/key4hep/k4geo/pull/373))
+  FCCSWEndcapTurbine_k4geo segmentation: Correct the y position for cells in the endcap on the -z side of the detector (a minus sign is needed since this detector is a mirrored copy of the +z side).
+
+* 2024-08-09 jmcarcell ([PR#368](https://github.com/key4hep/k4geo/pull/368))
+  - Clean up includes
+
+* 2024-08-09 Alvaro Tolosa Delgado ([PR#365](https://github.com/key4hep/k4geo/pull/365))
+  - IDEA_o1_v03: Dual Readout Calorimeter (DRC) is not loaded by default
+     - Added Test for IDEA with DRC
+
+* 2024-08-09 jmcarcell ([PR#353](https://github.com/key4hep/k4geo/pull/353))
+  - muonSystemMuRWELL_o1_v01.cpp: Use + std::to_string to append to a string, instead of adding an integer to a string (introduced in https://github.com/key4hep/k4geo/pull/322). Adding a string and an integer cuts the string by as many characters as the value of the integer.
+
+* 2024-08-08 BrieucF ([PR#371](https://github.com/key4hep/k4geo/pull/371))
+  - Put the stl files for CAD beampipe, downloaded with cmake, at the right place
+
+* 2024-08-06 Alvaro Tolosa Delgado ([PR#359](https://github.com/key4hep/k4geo/pull/359))
+  - New CMake option `INSTALL_BEAMPIPE_STL_FILES` can be used to download the STL (CAD model) beam pipe files from the web EOS
+
+* 2024-08-06 Sungwon Kim ([PR#346](https://github.com/key4hep/k4geo/pull/346))
+  - Add DRC geometry construction code under `detector/calorimeter/dual-readout` directory
+  - Add .xml compact files under `FCCee/IDEA/compact/IDEA_o1_v03` directory
+  - Add custom SD action, output file, fast simulation (boosting optical photon transportation) for Monolithic fiber DRC under `plugin` directory
+  - Fixed CMakeLists to compile all above
+
+* 2024-07-30 Leonhard Reichenbach ([PR#362](https://github.com/key4hep/k4geo/pull/362))
+  - TrackerEndcap_o2_v06_geo: Fixed endcap radius calculation for the event display (CED), and only the event display, fixes #355
+
+* 2024-07-30 jmcarcell ([PR#360](https://github.com/key4hep/k4geo/pull/360))
+  - Add aliases for the detectorCommon and detectorSegmentations libraries
+
+* 2024-07-22 Giovanni Marchiori ([PR#357](https://github.com/key4hep/k4geo/pull/357))
+  - [ALLEGRO_o1_v03 ECAL barrel] Get number of modules passed to readout from constant defined before in xml
+
+* 2024-07-22 Erich Varnes ([PR#347](https://github.com/key4hep/k4geo/pull/347))
+  - Added a new driver, `ECalEndcap_Turbine_o1_v01`, to build a Noble Liquid ECAL endcap with inclined blades (aka turbine geometry)
+  - Added a new segmentation (`FCCSWEndcapTurbine_k4geo`) for the Noble Liquid ECAL endcap turbine geometry
+  - Replaced the ALLEGRO_o1_v03 ECAL endcap made of disks perpendicular to the z axis by the turbine geometry built with `ECalEndcap_Turbine_o1_v01`
+
+* 2024-07-19 aciarma ([PR#344](https://github.com/key4hep/k4geo/pull/344))
+  - added `k4geo/FCCee/MDI` folder 
+  - put the shape based beampipe in `MDI_o1_v00`
+  - prepared `k4geo/FCCee/MDI/compact/MDI_o1_v01/` which will contain the CAD beampipe
+  - modified the main compact files of `ALLEGRO_o1_v03` and `IDEA_o1_v03` to include the centralized beampipe and prepare them for the CAD ones
+  - removed `HOMAbsorbers.xml` from ALLEGRO_o1_v03 since they are not needed with the low impedance beam pipe.
+
+* 2024-07-16 jmcarcell ([PR#354](https://github.com/key4hep/k4geo/pull/354))
+  - Rename the lcgeoTests folder to test
+
+* 2024-07-08 mahmoudali2 ([PR#322](https://github.com/key4hep/k4geo/pull/322))
+  - Define the first draft of the detailed muon system, which depend on mosaics of 50 * 50 cm^2 mRWELL chambers.
+  - Define a suitable XML for the new detailed version.
+  - Describe µRWELL materials.
+  - Add the parameters of the muon system into the full IDEA implementation.
+
+* 2024-07-04 Giovanni Marchiori ([PR#349](https://github.com/key4hep/k4geo/pull/349))
+  - fix detector type in ALLEGRO v03 ECAL calibration scripts
+
+* 2024-07-04 jmcarcell ([PR#348](https://github.com/key4hep/k4geo/pull/348))
+  - CMake: fix printout for missing header file, by printing the actual missing file
+
+* 2024-06-28 tmadlener ([PR#343](https://github.com/key4hep/k4geo/pull/343))
+  - Make the TPC have detector ID 4 and use a consistent cellID for all tracking detectors in `ILD_l5_v11` in order to make tracking code run again
+
+* 2024-06-19 jmcarcell ([PR#342](https://github.com/key4hep/k4geo/pull/342))
+  - Remove a warning by deleting an unused string
+
+* 2024-06-12 jmcarcell ([PR#340](https://github.com/key4hep/k4geo/pull/340))
+  - Remove a CentOS7 workflow using the CLIC nightlies
+
+* 2024-06-10 Frank Gaede ([PR#333](https://github.com/key4hep/k4geo/pull/333))
+  - fix CED event display for CLIC like detectors using TrackerEndcap_o2_v0x_geo 
+         -  fix nPetals in ZDiskPetalsData (for CEDViewer) to use nmodules (e.g. 48 ) rather than nrings
+         -  store the number of rings in  `ZDiskPetalsData::sensorsPerPetal`
+
+* 2024-06-06 BrieucF ([PR#339](https://github.com/key4hep/k4geo/pull/339))
+  - [FCCee-ALLEGRO_o1_v03] Vertex detector and drift chamber updated to the last IDEA version
+  - [FCCee-ALLEGRO_o1_v03] Added solenoidal and MDI magnetic fields
+  - [FCCee-ALLEGRO_o1_v03]  Removed ALLEGRO_o1_v03_ecalonly.xml and ALLEGRO_o1_v03_trackeronly.xml to ease maintenance (they can be obtained by commenting out sub-detectors)
+
+* 2024-05-30 BrieucF ([PR#335](https://github.com/key4hep/k4geo/pull/335))
+  - Fix for the IDEA_o1_v03 solenoid position
+
+* 2024-05-15 Alvaro Tolosa Delgado ([PR#330](https://github.com/key4hep/k4geo/pull/330))
+  - Implementation of IDEA drift chamber, o1_v02. It is based on an original description. The code was redesign to be light. Standalone overlap ctest added.
+
+* 2024-05-06 Zhibo WU ([PR#334](https://github.com/key4hep/k4geo/pull/334))
+  - xtalk_neighbors_moduleThetaMergedSegmentation.cpp: change the loop variable itField from int to size_t, in order to remove a compilation warning.
+
+* 2024-04-18 Zhibo WU ([PR#331](https://github.com/key4hep/k4geo/pull/331))
+  - Add new functions related to the crosstalk neighbour finding for ALLEGRO ECAL barrel cells.
+
+* 2024-04-16 Giovanni Marchiori ([PR#332](https://github.com/key4hep/k4geo/pull/332))
+  - New version of ALLEGRO detector o1_v03 with ecal barrel with 11 layers with cell corners projective along phi. No changes to the other sub detectors.
+
+* 2024-03-24 BrieucF ([PR#326](https://github.com/key4hep/k4geo/pull/326))
+  - CLD_o2_v06: add new detector model
+
+* 2024-03-21 Brieuc Francois ([PR#329](https://github.com/key4hep/k4geo/pull/329))
+  - Add a description of CLD_o4_v05 in the FCCee README
+
+* 2024-03-21 BrieucF ([PR#327](https://github.com/key4hep/k4geo/pull/327))
+  - Add a solenoid and magnetic fields for IDEA. The solenoid has the right material budget (0.75 X0) and spacial extent but its internals should be revised by ultra-thin solenoid designers.
+  - Add the endplate lead absorbers for IDEA
+
+* 2024-03-06 Anna Zaborowska ([PR#328](https://github.com/key4hep/k4geo/pull/328))
+  - Make LCIO an optional dependency. If LCIO is not found, some detectors (trackers) will not be built.
+
+* 2024-02-25 jmcarcell ([PR#324](https://github.com/key4hep/k4geo/pull/324))
+  - Remove the old key4hep build workflow since there is a newer one that builds for all the supported OSes
+
+* 2024-02-25 jmcarcell ([PR#302](https://github.com/key4hep/k4geo/pull/302))
+  - Clean up unused variables
+
+
+### DDMarlinPandora v00-12-02
+
+* 2024-08-28 tmadlener ([PR#30](https://github.com/iLCSoft/DDMarlinPandora/pull/30))
+  - Remove the no longer supported CentOS7 builds from the Key4hep based CI workflows
+
+* 2024-08-28 tmadlener ([PR#28](https://github.com/iLCSoft/DDMarlinPandora/pull/28))
+  - Make it possible to register ECAL energy corrections with Pandora similar to what is possible for the HCAL
+
+
+### MarlinTrkProcessors v02-12-06
+
+* 2024-08-28 Victor Schwan ([PR#72](https://github.com/iLCSoft/MarlinTrkProcessors/pull/72))
+  - Remove the hardcoded (ILD) detector names from the FullLDC tracking to allow its usage with the `v11` model of ILD.
+    - Keep defaults compatible with the non-hybrid ILD models
+
+* 2024-08-23 tmadlener ([PR#70](https://github.com/iLCSoft/MarlinTrkProcessors/pull/70))
+  - Add the `.clang-format` default file that is also used by other Key4hep repositories
+  - Add a basic `pre-commit` configuration to run formatting checks
+  - Run `clang-format` to fix all formatting issues
+
+* 2024-08-22 tmadlener ([PR#71](https://github.com/iLCSoft/MarlinTrkProcessors/pull/71))
+  - Fix warnings to make Key4hep based CI workflows pass again
+  - Remove CentOS7 from Key4hep based workflows since it is no longer supported
+
+
+### iLCUtil v01-07-03
+
+* 2024-05-28 Andre Sailer ([PR#35](https://github.com/iLCSoft/iLCUtil/pull/35))
+  - RPATH: set rpath to `$ORIGIN/../${CMAKE_INSTALL_LIBDIR}`
+
+* 2024-05-02 jmcarcell ([PR#34](https://github.com/iLCSoft/iLCUtil/pull/34))
+  - Write rpaths when installing. Fixes an issue introduced in https://github.com/iLCSoft/iLCUtil/pull/32 where rpaths are not being written.
+
+* 2024-05-02 tmadlener ([PR#33](https://github.com/iLCSoft/iLCUtil/pull/33))
+  - Bump the default c++ version to 17 as that is what we have been using for at least a few years now.
+
+* 2024-04-29 Frank Gaede ([PR#32](https://github.com/iLCSoft/iLCUtil/pull/32))
+  - replace `ilcsoft_default_rpath_settings.cmake` with the one from LCIO
+      -  see https://github.com/iLCSoft/LCIO/pull/121 
+  - this fixes the rpath settings for all iLCSoft tools using this script to work on MacOS
+  - (needed to install the key4hep stack on darwin)
+
+* 2024-04-29 Tao Lin ([PR#20](https://github.com/iLCSoft/iLCUtil/pull/20))
+  - Fix the problem: the system GSL may be picked. See details in https://github.com/key4hep/k4-spack/issues/77
+
+
+### GEAR v01-09-03
+
+* 2024-07-01 jmcarcell ([PR#10](https://github.com/iLCSoft/GEAR/pull/10))
+  - Fix warnings about not passing exceptions by reference
+  - Fix warnings about an implicit copy constructor defined
+  - Fix other warnings, about fallthroughs, a weird UTF-8 character (spanish accent in comments in spanish) and unused results
+
+### CEDViewer v01-20
+
+* 2024-07-23 tmadlener ([PR#28](https://github.com/iLCSoft/CEDViewer/pull/28))
+  - Add key4hep based CI workflows
+
+* 2024-07-23 Leonhard Reichenbach ([PR#27](https://github.com/iLCSoft/CEDViewer/pull/27))
+  - Added the processor parameter `DrawMCParticlesCreatedInSimulation` to enable drawing of the MCParticles that were created in the simulation.
+  
+### CED v01-10
+
+* 2024-07-25 tmadlener ([PR#13](https://github.com/iLCSoft/CED/pull/13))
+  - Make sure that all detector layers have a keyboard shortcut and that they can be properly addressed by that after [#11](https://github.com/iLCSoft/CED/pull/11)
+  - Refactor the `keypressed` function and eliminate a few previously undetected clashes in available keyboard shortcuts 
+    - `t`, `u`, `y`, `i` were bound twice and now exclusively used for toggling data layers
+
+* 2024-07-23 tmadlener ([PR#14](https://github.com/iLCSoft/CED/pull/14))
+  - Remove CentOS7 from the Key4hep based CI workflows
+
+* 2024-03-27 Leonhard Reichenbach ([PR#11](https://github.com/iLCSoft/CED/pull/11))
+  - Increased the number of possible detector layers to 40
+
+### KiTrack v01-10-01
+
+* 2024-08-22 tmadlener ([PR#4](https://github.com/iLCSoft/KiTrack/pull/4))
+  - Move CI to github actions and remove travis-ci config
+  - Fix c++ warnings and enable `-Werror` for CI

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -74,7 +74,17 @@ None
 * 2024-04-15 tmadlener ([PR#188](https://github.com/iLCSoft/LCIO/pull/188))
   - Make the `PIDHandler` usable as `const` object by marking getters that do not mutate internal state as `const`
 
-### Marlin v01-19-04 (merged notes from several tags)
+### Marlin v01-19-05 (merged notes from several tags)
+
+* 2025-04-25 Thomas Madlener ([PR#65](https://github.com/iLCSoft/Marlin/pull/65))
+  - Make sure to install libraries to `CMAKE_INSTALL_LIBDIR` to ensure the `RPATH` embedded in executables and binaries points to the correct place
+
+* 2025-03-31 jmcarcell ([PR#64](https://github.com/iLCSoft/Marlin/pull/64))
+  - Add LANGUAGES CXX to the top level CMakeLists.txt to disable checks for a C compiler
+
+* 2025-03-31 jmcarcell ([PR#63](https://github.com/iLCSoft/Marlin/pull/63))
+  - Bump the minimum version of CMake to 3.5, to be able to compile with CMake 4.0
+  - Change a `get_property...LOCATION` (doesn't work with CMake 4.0) and hardcode a set with the location of the library, only used for testing
 
 * 2025-01-13 jmcarcell ([PR#62](https://github.com/iLCSoft/Marlin/pull/62))
   - Include GNUInstallDirs to set CMAKE_INSTALL_LIBDIR so that the default rpath is correct in MacOS and can be used in downstream projects, like in `k4MarlinWrapper`

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -9,11 +9,11 @@ This patch release comes with several fundamental updates:
 - Python version updated from 3.9 to 3.11
 
 ## External software versions upgrade
-- ROOT 6.30/04 :arrow_right: 6.32/08
-- DD4hep 01-28 :arrow_right: 01-30
-- Geant4 11.2.1 :arrow_right: 11.2.2
-- CMake 3.28.3 :arrow_right: 3.30.5
-- boost 1.84.0 :arrow_right: 1.86.0
+- ROOT 6.30/04 :arrow_right: 6.32.10
+- DD4hep 01-28 :arrow_right: 01-31
+- Geant4 11.2.1 :arrow_right: 11.3.1
+- CMake 3.28.3 :arrow_right: 3.31.6
+- boost 1.84.0 :arrow_right: 1.87.0
 - FastJet 3.4.2 :arrow_right: 3.4.3
 - FastJet Contrib 1.054 :arrow_right: 1.056
 - Qt 5.13.1 :arrow_right: 5.15.15 (from underlying LCG_106 stack)

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -465,4 +465,21 @@ None
   - Move CI to github actions and remove travis-ci config
   - Fix c++ warnings and enable `-Werror` for CI
 
-### PandoraPFANew v04-11-01
+### LCFIPlus v00-11
+
+* 2025-02-24 Thomas Madlener ([PR#73](https://github.com/LCFIPlus/LCFIPlus/pull/73))
+  - Add the `key4hep-build` action that builds LCFIPlus on top of the Key4hep nightlies and releases.
+
+* 2025-02-24 Thomas Madlener ([PR#72](https://github.com/LCFIPlus/LCFIPlus/pull/72))
+  - Make sure to explicitly have the LCIO headers available for building against them.
+  - Backport a patch that has been part of the [spack recipe in key4hep-spack](https://github.com/key4hep/key4hep-spack/blob/main/packages/lcfiplus/package.py) for 4 years now.
+
+* 2022-12-16 Ryo YONAMINE ([PR#67](https://github.com/LCFIPlus/LCFIPlus/pull/67))
+  - Make consistent between primary vertex condition and the one for ip refitting in secondary vertex finding.
+
+* 2022-12-16 Matthias Artur Weber ([PR#48](https://github.com/LCFIPlus/LCFIPlus/pull/48))
+  LCFIPLUS JetFinder
+  - new procedure avoids adding tracks originating from a vertex to a jet twice
+  - if a track is very close to a vertex, check if track already part of the vertex jet before adding it to the jet
+
+### PandoraPFANew v04-15-00

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -24,7 +24,15 @@ None
 
 ## Packages changed wrt. v02-03-03
 
-### LCIO v02-22-02 (merged notes for several tags)
+### LCIO v02-22-04 (merged notes for several tags)
+
+* 2025-02-03 Thomas Madlener ([PR#201](https://github.com/iLCSoft/LCIO/pull/201))
+  - Make it possible to create empty subset collections during patching
+    - Appending a **`*`** (star) to the collection type name (no spaces) will make this collection an empty subset collection if it is not already present.
+    - Fixes [#199 ](https://github.com/iLCSoft/LCIO/issues/199)
+
+* 2024-10-20 Valentin Volkl ([PR#197](https://github.com/iLCSoft/LCIO/pull/197))
+  - Fix compilation on MacOS by adding missing include in dumpmctree-dot.cc
 
 * 2024-09-05 tmadlener ([PR#193](https://github.com/iLCSoft/LCIO/pull/193))
   - Add functionality to `CheckCollections` that makes it possible to add missing ParticleID algorithms to ReconstructedParticle collections
@@ -62,7 +70,10 @@ None
 * 2024-04-15 tmadlener ([PR#188](https://github.com/iLCSoft/LCIO/pull/188))
   - Make the `PIDHandler` usable as `const` object by marking getters that do not mutate internal state as `const`
 
-### Marlin v01-19-03
+### Marlin v01-19-04 (merged notes from several tags)
+
+* 2025-01-13 jmcarcell ([PR#62](https://github.com/iLCSoft/Marlin/pull/62))
+  - Include GNUInstallDirs to set CMAKE_INSTALL_LIBDIR so that the default rpath is correct in MacOS and can be used in downstream projects, like in `k4MarlinWrapper`
 
 * 2024-08-22 tmadlener ([PR#59](https://github.com/iLCSoft/Marlin/pull/59))
   - Make sure the `LCIO::lcio` target is also defined in packages consuming Marlin (necessary after #56)
@@ -379,7 +390,14 @@ None
   - Fix the problem: the system GSL may be picked. See details in https://github.com/key4hep/k4-spack/issues/77
 
 
-### GEAR v01-09-03
+### GEAR v01-09-03 (merged notes from several tags)
+
+* 2025-01-13 Thomas Madlener ([PR#15](https://github.com/iLCSoft/GEAR/pull/15))
+  - Switch to central Key4hep CI build workflows and remove clicdp nightlies based ones
+  - Fix warnings that are now enabled
+
+* 2025-01-13 jmcarcell ([PR#14](https://github.com/iLCSoft/GEAR/pull/14))
+  - Add GNUInstallDirs to set CMAKE_INSTALL_LIBDIR so that the default rpath is correct and can be used in downstream projects, like in `k4MarlinWrapper`
 
 * 2024-07-01 jmcarcell ([PR#10](https://github.com/iLCSoft/GEAR/pull/10))
   - Fix warnings about not passing exceptions by reference

--- a/doc/release_notes_ilcsoft_v02-03-04.md
+++ b/doc/release_notes_ilcsoft_v02-03-04.md
@@ -16,7 +16,7 @@ This patch release comes with several fundamental updates:
 - boost 1.84.0 :arrow_right: 1.86.0
 - FastJet 3.4.2 :arrow_right: 3.4.3
 - FastJet Contrib 1.054 :arrow_right: 1.056
-- Qt 5.13.1 :arrow_right: 5.15.15
+- Qt 5.13.1 :arrow_right: 5.15.15 (from underlying LCG_106 stack)
 
 # New packages
 

--- a/docker/cvmfs-install/Dockerfile.cvmfs-install.alma9
+++ b/docker/cvmfs-install/Dockerfile.cvmfs-install.alma9
@@ -1,0 +1,38 @@
+FROM gitlab-registry.cern.ch/linuxsupport/alma9-base
+
+LABEL product="iLCSoft-cvmfs-install-alma9"
+LABEL maintainer="thomas.madlener@desy.de"
+LABEL description="Image to install iLCSoft on CVMFS for Alma9"
+LABEL os="Alma9"
+
+RUN dnf update -y && \
+    dnf groupinstall -y "Development Tools" && \
+    dnf install -y \
+      curl \
+      wget \
+      openssl-devel \
+      freeglut-devel \
+      tar \
+      bzip2 \
+      which \
+      libX11-devel \
+      libXext-devel \
+      libXmu-devel \
+      libXft-devel \
+      libXpm-devel \
+      doxygen \
+      libuuid-devel \
+      perl-core \
+      glibc-locale-source \
+      glibc-langpack-en \
+      subversion && \
+   dnf clean all && rm -rf /var/cache/yum
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
+CMD ["/bin/bash"]

--- a/ilcsoft/__init__.py
+++ b/ilcsoft/__init__.py
@@ -33,6 +33,7 @@ from .pandoranew import PandoraPFANew
 from .pandoranew import PandoraAnalysis
 from .pandoranew import MarlinPandora
 from .lcfivertex import LCFIVertex
+from .lcfiplus import LCFIPlus
 from .eutelescope import Eutelescope
 from .overlay import Overlay
 from .marlintpc import MarlinTPC

--- a/ilcsoft/boost.py
+++ b/ilcsoft/boost.py
@@ -44,19 +44,21 @@ class Boost(BaseILC):
         BaseILC.setMode(self, mode)
 
         if( self.mode == "install" ):
-            if( Version( self.version ) > "1.76.0" ):
-                # Example: https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz
-                self.download.url = "https://boostorg.jfrog.io/artifactory/main/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
-            elif( Version( self.version ) > "1.70.0" ):
-                # https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz
-                self.download.url = "https://boostorg.jfrog.io/artifactory/main/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
-            elif( Version( self.version ) > "1.63.0" ):
-                # Example: https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
-                self.download.url = "https://dl.bintray.com/boostorg/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
+            self.download.url = f"https://sourceforge.net/projects/boost/files/boost/{self.version}/boost_{self.version.replace('.', '_')}.tar.gz"
 
-            else:
-                # Example: https://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz
-                self.download.url = "https://sourceforge.net/projects/boost/files/boost/%s/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
+            # if( Version( self.version ) > "1.76.0" ):
+            #     # Example: https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz
+            #     self.download.url = "https://boostorg.jfrog.io/artifactory/main/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
+            # elif( Version( self.version ) > "1.70.0" ):
+            #     # https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz
+            #     self.download.url = "https://boostorg.jfrog.io/artifactory/main/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
+            # elif( Version( self.version ) > "1.63.0" ):
+            #     # Example: https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+            #     self.download.url = "https://dl.bintray.com/boostorg/release/%s/source/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
+
+            # else:
+            #     # Example: https://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz
+            #     self.download.url = "https://sourceforge.net/projects/boost/files/boost/%s/boost_%s.tar.gz" % (self.version, self.version.replace( "." , "_" ) )
         self.cmakeconfig = self.installPath + "/lib/cmake/Boost-" + self.version
         
     def compile(self):

--- a/ilcsoft/gear.py
+++ b/ilcsoft/gear.py
@@ -23,8 +23,8 @@ class GEAR(BaseILC):
         self.reqmodules = [ "CLHEP" ]
 
         self.reqfiles = [
-                ["lib/libgear.a", "lib/libgear.so", "lib/libgear.dylib"],
-                ["lib/libgearxml.a", "lib/libgearxml.so", "lib/libgearxml.dylib"]
+                ["lib64/libgear.a", "lib64/libgear.so", "lib/libgear.a", "lib/libgear.so", "lib/libgear.dylib"],
+                ["lib64/libgearxml.a", "lib64/libgearxml.so", "lib/libgearxml.a", "lib/libgearxml.so", "lib/libgearxml.dylib"]
         ]
 
     def compile(self):

--- a/ilcsoft/lcfiplus.py
+++ b/ilcsoft/lcfiplus.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from .marlinpkg import MarlinPKG
+from .baseilc import BaseILC
+
+
+class LCFIPlus(MarlinPKG):
+    """LCFIPlus configuration for installing and configuring LCFIPlus"""
+
+    def __init__(self, userInput):
+        MarlinPKG.__init__(self, "LCFIPlus", userInput)
+
+        self.reqmodules = ["LCIO", "GEAR", "ROOT", "Marlin", "MarlinUtil", "LCFIVertex"]
+        self.reqfiles = [["lib/libLCFIPlus.so", "lib/LCFIPlus.dylib"]]
+
+        self.download.type = "Github"
+        self.download.gituser = "lcfiplus"
+        self.download.gitrepo = "LCFIPlus"
+
+    def postCheckDeps(self):
+        BaseILC.postCheckDeps(self)
+
+        self.parent.module("Marlin").envpath["MARLIN_DLL"].append(
+            f"{self.installPath}/install/lib/libLCFIPlus{self.shlib_ext}"
+        )
+        self.envpath["ROOT_INCLUDE_PATH"].append(f"{self.installPath}/include")
+        self.envpath["LD_LIBRARY_PATH"].append(f"{self.installPath}/install/lib")

--- a/ilcsoft/lcfivertex.py
+++ b/ilcsoft/lcfivertex.py
@@ -23,8 +23,8 @@ class LCFIVertex(MarlinPKG):
 
         # optional modules
         self.optmodules = [ "AIDA" ]
-        self.reqfiles = [ ["lib/libLCFIVertex.so", "lib/libLCFIVertex.dylib" ],
-                          ["lib/libLCFIVertexProcessors.so", "lib/libLCFIVertexProcessors.dylib"] ]
+        self.reqfiles = [ ["install/lib/libLCFIVertex.so", "install/lib/libLCFIVertex.dylib" ],
+                          ["install/lib/libLCFIVertexProcessors.so", "install/lib/libLCFIVertexProcessors.dylib"] ]
 
         # cvs root
         self.download.root="marlinreco"
@@ -40,9 +40,9 @@ class LCFIVertex(MarlinPKG):
 
         # fill MARLIN_DLL
         self.parent.module('Marlin').envpath["MARLIN_DLL"].append(
-          self.installPath+"/lib/libLCFIVertexProcessors"+self.shlib_ext )
+          self.installPath+"/install/lib/libLCFIVertexProcessors"+self.shlib_ext )
 
-        self.envpath["LD_LIBRARY_PATH"].append( self.installPath+"/lib" )
+        self.envpath["LD_LIBRARY_PATH"].append( self.installPath+"install/lib" )
 
 #        print "+ Unpacking Boost..."
 #        os.chdir( self.installPath )

--- a/ilcsoft/lcio.py
+++ b/ilcsoft/lcio.py
@@ -104,4 +104,4 @@ class LCIO(BaseILC):
             self.envpath["LD_LIBRARY_PATH"].append( "$LCIO/lib64" )
         self.envpath["PYTHONPATH"].append( "$LCIO/python" )
         self.envpath["PYTHONPATH"].append( "$LCIO/python/examples" )
-
+        self.envpath["ROOT_INCLUDE_PATH"].append( self.instalPath + "/include" )

--- a/ilcsoft/lcio.py
+++ b/ilcsoft/lcio.py
@@ -104,4 +104,4 @@ class LCIO(BaseILC):
             self.envpath["LD_LIBRARY_PATH"].append( "$LCIO/lib64" )
         self.envpath["PYTHONPATH"].append( "$LCIO/python" )
         self.envpath["PYTHONPATH"].append( "$LCIO/python/examples" )
-        self.envpath["ROOT_INCLUDE_PATH"].append( self.instalPath + "/include" )
+        self.envpath["ROOT_INCLUDE_PATH"].append( self.installPath + "/include" )

--- a/ilcsoft/marlin.py
+++ b/ilcsoft/marlin.py
@@ -22,7 +22,8 @@ class Marlin(BaseILC):
         self.download.gituser = 'iLCSoft'
         self.download.gitrepo = 'Marlin'
 
-        self.reqfiles = [ ["lib/libMarlin.a", "lib/libMarlin.so", "lib/libMarlin.dylib"], ["bin/Marlin"] ]
+        self.reqfiles = [ ["lib/libMarlin.a", "lib/libMarlin.so", "lib/libMarlin.dylib"
+                           "lib64/libMarlin.a", "lib64/libMarlin.so"], ["bin/Marlin"] ]
 
         # LCIO is required for building Marlin
         self.reqmodules = [ "LCIO", "GEAR" ]

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -24,6 +24,7 @@ class ConfigPKG(BaseILC):
         self.hasCMakeBuildSupport = False
         self.hasCMakeFindSupport = False
         self.skipCompile = True
+        self.envcmake["CMAKE_INSTALL_PREFIX"] = "../install"
 
 class MarlinPKG(BaseILC):
     """ Responsible for Marlin Packages installation process. """
@@ -60,7 +61,7 @@ class MarlinPKG(BaseILC):
     def checkInstall(self, abort=True):
         BaseILC.checkInstall(self)
         if self.name not in ("MarlinUtil", "PandoraPFANew", "Physsim", "LCFIVertex"):
-            for libdir in ("/lib/", "/lib64/"):
+            for libdir in ("install/lib/", "install/lib64/"):
                 libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
                 print("MarlinDLL: looking for ", libname)
                 if os.path.exists(libname):

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -37,7 +37,8 @@ class MarlinPKG(BaseILC):
         # Marlin packages just provide libraries. 
         # They are not supposed to be found via CMake 
         self.hasCMakeFindSupport = False
-        self.envcmake["CMAKE_INSTALL_PREFIX"] = "../install"
+        self.envcmake["CMAKE_INSTALL_PREFIX"] = self.installPath + "/install"
+        self.cmakeconfig = self.installPath + "/install"
         
     def compile(self):
         """ compile MarlinPKG """

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -24,7 +24,6 @@ class ConfigPKG(BaseILC):
         self.hasCMakeBuildSupport = False
         self.hasCMakeFindSupport = False
         self.skipCompile = True
-        self.envcmake["CMAKE_INSTALL_PREFIX"] = "../install"
 
 class MarlinPKG(BaseILC):
     """ Responsible for Marlin Packages installation process. """
@@ -38,6 +37,7 @@ class MarlinPKG(BaseILC):
         # Marlin packages just provide libraries. 
         # They are not supposed to be found via CMake 
         self.hasCMakeFindSupport = False
+        self.envcmake["CMAKE_INSTALL_PREFIX"] = "../install"
         
     def compile(self):
         """ compile MarlinPKG """

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -37,11 +37,11 @@ class MarlinPKG(BaseILC):
         # Marlin packages just provide libraries. 
         # They are not supposed to be found via CMake 
         self.hasCMakeFindSupport = False
-        self.envcmake["CMAKE_INSTALL_PREFIX"] = self.installPath + "/install"
 
     def setMode(self, mode):
         BaseILC.setMode(self, mode)
 
+        self.envcmake["CMAKE_INSTALL_PREFIX"] = self.installPath + "/install"
         self.cmakeconfig = self.installPath + "/install"
 
     def compile(self):

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -38,8 +38,12 @@ class MarlinPKG(BaseILC):
         # They are not supposed to be found via CMake 
         self.hasCMakeFindSupport = False
         self.envcmake["CMAKE_INSTALL_PREFIX"] = self.installPath + "/install"
+
+    def setMode(self, mode):
+        BaseILC.setMode(self, mode)
+
         self.cmakeconfig = self.installPath + "/install"
-        
+
     def compile(self):
         """ compile MarlinPKG """
         

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -65,7 +65,7 @@ class MarlinPKG(BaseILC):
 
     def checkInstall(self, abort=True):
         BaseILC.checkInstall(self)
-        if self.name not in ("MarlinUtil", "PandoraPFANew", "Physsim", "LCFIVertex"):
+        if self.name not in ("MarlinUtil", "PandoraPFANew", "Physsim", "LCFIVertex", "LCFIPlus"):
             for libdir in ("/install/lib/", "/install/lib64/"):
                 libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
                 print("MarlinDLL: looking for ", libname)

--- a/ilcsoft/marlinpkg.py
+++ b/ilcsoft/marlinpkg.py
@@ -61,7 +61,7 @@ class MarlinPKG(BaseILC):
     def checkInstall(self, abort=True):
         BaseILC.checkInstall(self)
         if self.name not in ("MarlinUtil", "PandoraPFANew", "Physsim", "LCFIVertex"):
-            for libdir in ("install/lib/", "install/lib64/"):
+            for libdir in ("/install/lib/", "/install/lib64/"):
                 libname = self.installPath + libdir + "lib" + self.name + self.shlib_ext
                 print("MarlinDLL: looking for ", libname)
                 if os.path.exists(libname):

--- a/ilcsoft/qt5.py
+++ b/ilcsoft/qt5.py
@@ -23,7 +23,7 @@ class Qt5(BaseILC):
         self.hasCMakeFindSupport = True
         self.download.supportHEAD = False
         self.download.supportedTypes = [ "git" ] 
-        self.download.svnurl = 'https://github.com/qt/qt5.git'
+        self.download.svnurl = 'https://code.qt.io/qt/qt5.git'
 
         self.reqfiles = [
             ["lib/libQt5Core.so", "lib64/libQt5Core.so", "lib/libQt5Core.dylib", "lib/libQt5Core.la"],
@@ -95,7 +95,7 @@ class Qt5(BaseILC):
         qt_cfg_options = " -opensource -confirm-license -nomake tests -make libs "
         cxxStandard = self.envcmake.get("CMAKE_CXX_STANDARD", None)
         if cxxStandard:
-            qt_cfg_options += " -c++std c++" + str(cxxStandard)
+            qt_cfg_options += " -c++std c++17"
         
         if( os_system( "../" + self.name + "/configure -prefix " + self.installPath + qt_cfg_options
                 + " 2>&1 | tee -a " + self.logfile ) != 0 ):

--- a/ilcsoft/root.py
+++ b/ilcsoft/root.py
@@ -113,9 +113,9 @@ class ROOT(BaseILC):
         if Version(self.version) < "6.30":
             self.envcmake.setdefault( 'gsl_shared',     'ON' )
             self.envcmake.setdefault( 'builtin_gsl',    'OFF' ) # we provide GSL, don't recompile it !
+            self.envcmake.setdefault( 'minuit2',        'ON' )
 
         self.envcmake.setdefault( 'gdml',           'ON' )
-        self.envcmake.setdefault( 'minuit2',        'ON' )
         self.envcmake.setdefault( 'roofit',         'ON' )
         self.envcmake.setdefault( 'unuran',         'ON' )
         self.envcmake.setdefault( 'xrootd',         'ON' )
@@ -138,9 +138,12 @@ class ROOT(BaseILC):
             # Need to symlink two cmake scripts that are not installed properly
             # otherwise and would break packages that depend on ROOT
             for mod in ['RootMacros.cmake', 'RootTestDriver.cmake']:
-                link_path = os.path.join(self.installPath, 'cmake', mod)
-                src = os.path.join(self.installPath, 'cmake', 'modules', mod)
-                os.symlink(src, link_path)
+                try:
+                    link_path = os.path.join(self.installPath, 'cmake', mod)
+                    src = os.path.join(self.installPath, 'cmake', 'modules', mod)
+                    os.symlink(src, link_path)
+                except FileExistsError:
+                    pass
 
     def postCheckDeps(self):
         BaseILC.postCheckDeps(self)

--- a/ilcsoft/util.py
+++ b/ilcsoft/util.py
@@ -34,7 +34,7 @@ def os_system( cmd ):
     """ forces os.system calls wto use bash """
     cmd = cmd.replace('"',r'\"')
     ##print('os_system: ', 'bash -c "'+cmd+'"')
-    return os.system('pwd ; bash -c "'+cmd+'"')
+    return os.system('pwd ; bash -o pipefail -c "'+cmd+'"')
 
 #--------------------------------------------------------------------------------
 

--- a/ilcsoft/xercesc.py
+++ b/ilcsoft/xercesc.py
@@ -33,7 +33,7 @@ class XercesC(BaseILC):
         ]]
     def setMode(self, mode):
         BaseILC.setMode(self, mode)
-        self.cmakeconfig = self.installPath + "/lib/cmake/XercesC"
+        self.cmakeconfig = self.installPath
     
     def compile(self):
         """ compile XercesC """

--- a/releases/v02-03/release-base.cfg
+++ b/releases/v02-03/release-base.cfg
@@ -119,8 +119,6 @@ geant4.envcmake["GEANT4_USE_SYSTEM_CLHEP"]='ON'
 geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
 geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
 geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
-#geant4.envcmake["GEANT4_BUILD_CXXSTD"]='c++' + str(cxx_standard)
-geant4.envcmake["GEANT4_BUILD_CXXSTD"]=str(cxx_standard)
 geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='7200'
 
 #geant4.envcmake["QT_QMAKE_EXECUTABLE"]=/path/to/qmake

--- a/releases/v02-03/release-base.cfg
+++ b/releases/v02-03/release-base.cfg
@@ -132,7 +132,6 @@ ilcsoft.module("ROOT").download.type="wget"
 ilcsoft.module("ROOT").envcmake['root7']="ON"
 ilcsoft.module("ROOT").envcmake['webgui']="ON"
 ilcsoft.module("ROOT").envcmake['builtin_xrootd'] = "OFF"
-ilcsoft.module("ROOT").envcmake['clad'] = "OFF"  # fails to build
 
 ilcsoft.install( CLHEP( CLHEP_version ))
 ilcsoft.install( GSL( GSL_version ))

--- a/releases/v02-03/release-base.cfg
+++ b/releases/v02-03/release-base.cfg
@@ -118,6 +118,7 @@ geant4.envcmake["GEANT4_USE_SYSTEM_EXPAT"]='OFF' # ignored ??
 geant4.envcmake["GEANT4_USE_SYSTEM_CLHEP"]='ON'
 geant4.envcmake["GEANT4_USE_OPENGL_X11"]='ON'
 geant4.envcmake["GEANT4_USE_QT"]='ON' # requires qt
+geant4.envcmake["QT_QMAKE_EXECUTABLE"] = os.environ["QT_QMAKE_EXECUTABLE"]
 geant4.envcmake["GEANT4_BUILD_TLS_MODEL"]= 'global-dynamic'
 geant4.envcmake["GEANT4_INSTALL_DATA_TIMEOUT"]='7200'
 
@@ -130,11 +131,13 @@ ilcsoft.install( ROOT( ROOT_version ))
 ilcsoft.module("ROOT").download.type="wget"
 ilcsoft.module("ROOT").envcmake['root7']="ON"
 ilcsoft.module("ROOT").envcmake['webgui']="ON"
+ilcsoft.module("ROOT").envcmake['builtin_xrootd'] = "OFF"
+ilcsoft.module("ROOT").envcmake['clad'] = "OFF"  # fails to build
 
 ilcsoft.install( CLHEP( CLHEP_version ))
 ilcsoft.install( GSL( GSL_version ))
 ilcsoft.module("GSL").use_c11=True
-ilcsoft.install( Qt5( Qt5_version ))
+# ilcsoft.install( Qt5( Qt5_version ))
 
 # cmake
 ilcsoft.install( CMake( CMake_version ))

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -322,7 +322,7 @@ ilcsoft.link( ROOT( ilcPath + "root/" + ROOT_version ))
 
 ilcsoft.link( CLHEP( ilcPath + "CLHEP/" + CLHEP_version ))
 ilcsoft.link( GSL( ilcPath + "gsl/" + GSL_version ))
-ilcsoft.link( Qt5( ilcPath + "Qt5/" + Qt5_version ))
+# ilcsoft.link( Qt5( ilcPath + "Qt5/" + Qt5_version ))
 ilcsoft.link( Geant4( ilcPath + "geant4/" + Geant4_version ))
 
 ilcsoft.link( CondDBMySQL( ilcPath + "CondDBMySQL/" + CondDBMySQL_version ))

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -119,7 +119,7 @@ ilcsoft.module("PandoraPFANew").envcmake["PANDORA_MONITORING"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["LC_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["EXAMPLE_PANDORA_CONTENT"]='ON'
 ilcsoft.module("PandoraPFANew").envcmake["CMAKE_PREFIX_PATH"]='${ROOTSYS}/cmake'
-ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-std=c++%s' % cxx_standard
+ilcsoft.module("PandoraPFANew").envcmake["CMAKE_CXX_FLAGS"]='-std=c++%s -Wno-parentheses' % cxx_standard
 
 
 ilcsoft.install( LCFIVertex( LCFIVertex_version ))

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -229,11 +229,11 @@ ilcsoft.link( XercesC( ilcPath + "xercesc/" + XercesC_version ))
 
 # DD4hep
 ilcsoft.install( DD4hep( DD4hep_version )) 
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEANT4"]=1
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_LCIO"]=1
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_XERCESC"]=0
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_PYROOT"]=0
-ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]=1
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEANT4"]="ON"
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_LCIO"]="ON"
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_XERCESC"]="OFF"
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_PYROOT"]="OFF"
+ilcsoft.module("DD4hep").envcmake["DD4HEP_USE_GEAR"]="ON"
 # ilcsoft.module("DD4hep").envcmake["BOOST_ROOT"] = Boost_path
 
 

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -172,11 +172,7 @@ ilcsoft.module("FCalClusterer").download.gituser="FCALSW"
 ilcsoft.module("FCalClusterer").download.gitrepo="FCalClusterer"
 ilcsoft.module("FCalClusterer").addDependency( [ 'DD4hep', 'LCIO', 'ROOT', 'GSL', 'Marlin' ] )
 
-ilcsoft.install( MarlinPKG( "LCFIPlus", LCFIPlus_version ))
-ilcsoft.module("LCFIPlus").download.type="GitHub"
-ilcsoft.module("LCFIPlus").download.gituser="lcfiplus"
-ilcsoft.module("LCFIPlus").download.gitrepo="LCFIPlus"
-ilcsoft.module("LCFIPlus").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'Marlin', 'MarlinUtil', 'LCFIVertex'] )
+ilcsoft.install( LCFIPlus(LCFIPlus_version) )
 
 ilcsoft.install( MarlinPKG( "ForwardTracking", ForwardTracking_version ))
 ilcsoft.module("ForwardTracking").addDependency( [ 'LCIO', 'GEAR', 'ROOT', 'GSL', 'Marlin', 'MarlinUtil', 'MarlinTrk'] )

--- a/releases/v02-03/release-ilcsoft.cfg
+++ b/releases/v02-03/release-ilcsoft.cfg
@@ -95,14 +95,12 @@ ilcsoft.module("Marlin").envcmake["MARLIN_GUI"]='OFF'
 ilcsoft.install( MarlinPKG( "MarlinDD4hep", MarlinDD4hep_version ))
 ilcsoft.module("MarlinDD4hep").addDependency( [ 'Marlin', 'DD4hep', 'Root', 'DDKalTest'] )
 
-ilcsoft.install( MarlinPKG( "DDMarlinPandora", DDMarlinPandora_version ))
-ilcsoft.module("DDMarlinPandora").addDependency( [ 'Marlin', 'MarlinUtil', 'DD4hep', 'ROOT', 'PandoraPFANew', 'MarlinTrk'] )
-ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
-
-
 ilcsoft.install( MarlinUtil( MarlinUtil_version ))
 ilcsoft.module("MarlinUtil").envcmake["USE_EXTERNAL_CATCH2"]="OFF"
 
+ilcsoft.install( MarlinPKG( "DDMarlinPandora", DDMarlinPandora_version ))
+ilcsoft.module("DDMarlinPandora").addDependency( [ 'Marlin', 'MarlinUtil', 'DD4hep', 'ROOT', 'PandoraPFANew', 'MarlinTrk'] )
+ilcsoft.module("DDMarlinPandora").envcmake["CMAKE_CXX_FLAGS"]='-Wno-error'
 
 #----------  standard reco packages
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -182,7 +182,7 @@ RAIDA_version = "v01-11"
 
 MarlinUtil_version = "v01-18-02"
 
-Marlin_version = "v01-19-04"
+Marlin_version = "v01-19-05"
 
 MarlinDD4hep_version = "v00-06-02"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -204,7 +204,7 @@ MarlinKinfit_version = "v00-06-01"
 
 MarlinKinfitProcessors_version = "v00-05"
 
-PandoraPFANew_version = "v04-11-01"
+PandoraPFANew_version = "v04-12"
 
 PandoraAnalysis_version = "v02-00-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -8,30 +8,27 @@
 ###########################################
 
 # --------- ilcsoft release version ------------------------------------------
-ilcsoft_release = "v02-03-03"
+ilcsoft_release = "v02-03-04"
 # ----------------------------------------------------------------------------
 
 # which cxx standard to use
-cxx_standard = 17
+cxx_standard = 20
 
 # ===============================================================================
-# use a compiler that knows c++17, use e.g. scripts/use_gcc103_cvmfs_centos7.sh
+# use a compiler that knows c++20, use e.g. scripts/use_gcc103_cvmfs_centos7.sh
 #
 """
-# --- gcc from LCG_101
-source /cvmfs/sft.cern.ch/lcg/releases/gcc/10.3.0/x86_64-centos7/setup.sh
+# --- gcc from LCG_106
+source /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/setup.sh
 
-# --- python from LCG_101
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc10-opt/bin:${PATH}
-export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc10-opt/lib:${LD_LIBRARY_PATH}
-export PYTHONPATH=/cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc10-opt/lib/python3.9/site-packages
+# --- python from LCG_106
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/bin:${PATH}
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/lib:${LD_LIBRARY_PATH}
+export PYTHONPATH=/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/lib/python3.11/site-packages
 
-# --- git from LCG_101
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-e475b/x86_64-centos7-gcc10-opt/bin:${PATH}
-export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-e475b/x86_64-centos7-gcc10-opt/libexec/git-core
-
-# --- use a suitable mysql (also LCG_101)
-export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.4.20-c0154/x86_64-centos7-gcc10-opt
+# --- git from LCG_106
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-daa17/x86_64-el9-gcc13-opt/bin:${PATH}
+export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-daa17/x86_64-el9-gcc13-opt/libexec/git-core
 """
 # before starting the installation
 # ================================================================================
@@ -91,7 +88,7 @@ elif platform.system().lower().find("darwin") >= 0:
     platfDefault = "/usr/local"
 
 # ----- mysql --------------------------------------------------------
-MySQL_version = "10.4.20"
+MySQL_version = "10.5.20"
 MySQL_path = platfDefault
 
 # overwrite with a patch set in the environment
@@ -111,23 +108,23 @@ if my_mysql_path != None:
 
 # ======================= PACKAGE VERSIONS ===================================
 
-Geant4_version = "11.2.1"
+Geant4_version = "11.2.2"
 
 CLHEP_version = "2.4.7.1"
 
-ROOT_version = "6.30.04"
+ROOT_version = "6.32.06"
 
 GSL_version = "2.7"
 
 Qt5_version = "v5.15.15-lts-lgpl"
 
-CMake_version = "3.28.3"
+CMake_version = "3.31.0"
 
-CED_version = "v01-09-04"
+CED_version = "v01-10"
 
 SIO_version = "v00-02"
 
-Boost_version = "1.84.0"
+Boost_version = "1.86.0"
 
 Eigen_version = "3.4.0"
 
@@ -135,11 +132,11 @@ Eigen_version = "3.4.0"
 
 CondDBMySQL_version = "CondDBMySQL_ILC-0-9-7"
 
-ILCUTIL_version = "v01-07-02"
+ILCUTIL_version = "v01-07-03"
 
-FastJet_version = "3.4.2"
+FastJet_version = "3.4.3"
 
-FastJetcontrib_version = "1.054"
+FastJetcontrib_version = "1.056"
 
 # xerces-c (needed by geant4 for building gdml support - required by mokka)
 XercesC_version = "v3.2.3"
@@ -147,9 +144,9 @@ XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 # -------------------------------------------
 
-LCIO_version = "v02-21"
+LCIO_version = "v02-22-02"
 
-GEAR_version = "v01-09-02"
+GEAR_version = "v01-09-03"
 
 MarlinFastJet_version = "v00-05-03"
 
@@ -163,11 +160,11 @@ DDKalTest_version = "v01-07-01"
 
 MarlinTrk_version = "v02-09-02"
 
-MarlinTrkProcessors_version = "v02-12-05"
+MarlinTrkProcessors_version = "v02-12-06"
 
 Clupatra_version = "v01-03-01"
 
-KiTrack_version = "v01-10"
+KiTrack_version = "v01-10-01"
 
 KiTrackMarlin_version = "v01-13-02"
 
@@ -183,15 +180,15 @@ LCCD_version = "v01-05-02"
 
 RAIDA_version = "v01-11"
 
-MarlinUtil_version = "v01-17-02"
+MarlinUtil_version = "v01-18-01"
 
-Marlin_version = "v01-19-02"
+Marlin_version = "v01-19-03"
 
 MarlinDD4hep_version = "v00-06-02"
 
-DDMarlinPandora_version = "v00-12-01"
+DDMarlinPandora_version = "v00-12-02"
 
-MarlinReco_version = "v01-35"
+MarlinReco_version = "v01-36-01"
 
 FCalClusterer_version = "v01-00-06"
 
@@ -211,7 +208,7 @@ PandoraPFANew_version = "v03-25-03"
 
 PandoraAnalysis_version = "v02-00-01"
 
-CEDViewer_version = "v01-19-01"
+CEDViewer_version = "v01-20"
 
 Overlay_version = "v00-23"
 
@@ -227,16 +224,16 @@ BBQ_version = "v00-01-04"
 
 Garlic_version = "v03-01"
 
-DD4hep_version = "v01-28"
+DD4hep_version = "v01-30"
 
-DD4hepExamples_version = "v01-28"
+DD4hepExamples_version = "v01-30"
 
-lcgeo_version = "v00-20-00"
+lcgeo_version = "v00-21"
 
-podio_version = "v00-99"
+podio_version = "v01-01"
 
-edm4hep_version = "v00-10-05"
+edm4hep_version = "v00-99-01"
 
-k4edm4hep2lcioconv_version = "v00-08-02"
+k4edm4hep2lcioconv_version = "v00-09"
 
 Physsim_version = "v00-05"

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -112,13 +112,13 @@ Geant4_version = "11.2.2"
 
 CLHEP_version = "2.4.7.1"
 
-ROOT_version = "6.32.06"
+ROOT_version = "6.32.08"
 
 GSL_version = "2.7"
 
 Qt5_version = "v5.15.15-lts-lgpl"
 
-CMake_version = "3.31.0"
+CMake_version = "3.30.5"
 
 CED_version = "v01-10"
 
@@ -204,7 +204,7 @@ MarlinKinfit_version = "v00-06-01"
 
 MarlinKinfitProcessors_version = "v00-05"
 
-PandoraPFANew_version = "v03-25-03"
+PandoraPFANew_version = "v04-11-01"
 
 PandoraAnalysis_version = "v02-00-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -198,13 +198,13 @@ ILDPerformance_version = "v01-12"
 
 LCFIVertex_version = "v00-09"
 
-LCFIPlus_version = "v00-10-01"
+LCFIPlus_version = "HEAD"
 
 MarlinKinfit_version = "v00-06-01"
 
 MarlinKinfitProcessors_version = "v00-05"
 
-PandoraPFANew_version = "v04-12"
+PandoraPFANew_version = "v04-12-00"
 
 PandoraAnalysis_version = "v02-00-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -108,23 +108,23 @@ if my_mysql_path != None:
 
 # ======================= PACKAGE VERSIONS ===================================
 
-Geant4_version = "11.2.2"
+Geant4_version = "11.3.1"
 
 CLHEP_version = "2.4.7.1"
 
-ROOT_version = "6.32.08"
+ROOT_version = "6.32.10"
 
 GSL_version = "2.7"
 
 Qt5_version = "v5.15.15-lts-lgpl"
 
-CMake_version = "3.30.5"
+CMake_version = "3.31.6"
 
 CED_version = "v01-10"
 
 SIO_version = "v00-02"
 
-Boost_version = "1.86.0"
+Boost_version = "1.87.0"
 
 Eigen_version = "3.4.0"
 
@@ -224,7 +224,7 @@ BBQ_version = "v00-01-04"
 
 Garlic_version = "v03-01"
 
-DD4hep_version = "v01-30"
+DD4hep_version = "v01-31"
 
 DD4hepExamples_version = "v01-30"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -112,7 +112,7 @@ Geant4_version = "11.3.1"
 
 CLHEP_version = "2.4.7.1"
 
-ROOT_version = "6.32.10"
+ROOT_version = "6.32.12"
 
 GSL_version = "2.7"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -119,7 +119,7 @@ ROOT_version = "6.30.04"
 
 GSL_version = "2.7"
 
-Qt5_version = "v5.13.1"
+Qt5_version = "v5.15.15-lts-lgpl"
 
 CMake_version = "3.28.3"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -198,7 +198,7 @@ ILDPerformance_version = "v01-12"
 
 LCFIVertex_version = "v00-09"
 
-LCFIPlus_version = "HEAD"
+LCFIPlus_version = "v00-11"
 
 MarlinKinfit_version = "v00-06-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -144,9 +144,9 @@ XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 # -------------------------------------------
 
-LCIO_version = "v02-22-02"
+LCIO_version = "v02-22-04"
 
-GEAR_version = "v01-09-03"
+GEAR_version = "v01-09-04"
 
 MarlinFastJet_version = "v00-05-03"
 
@@ -176,13 +176,13 @@ LICH_version = "v00-01"
 
 GBL_version = "V02-02-01"
 
-LCCD_version = "v01-05-02"
+LCCD_version = "v01-05-03"
 
 RAIDA_version = "v01-11"
 
 MarlinUtil_version = "v01-18-01"
 
-Marlin_version = "v01-19-03"
+Marlin_version = "v01-19-04"
 
 MarlinDD4hep_version = "v00-06-02"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -146,7 +146,7 @@ XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 LCIO_version = "v02-22-04"
 
-GEAR_version = "v01-09-04"
+GEAR_version = "v01-09-05"
 
 MarlinFastJet_version = "v00-05-03"
 
@@ -160,7 +160,7 @@ DDKalTest_version = "v01-07-01"
 
 MarlinTrk_version = "v02-09-02"
 
-MarlinTrkProcessors_version = "v02-12-06"
+MarlinTrkProcessors_version = "v02-12-07"
 
 Clupatra_version = "v01-03-01"
 
@@ -180,15 +180,15 @@ LCCD_version = "v01-05-03"
 
 RAIDA_version = "v01-11"
 
-MarlinUtil_version = "v01-18-01"
+MarlinUtil_version = "v01-18-02"
 
 Marlin_version = "v01-19-04"
 
 MarlinDD4hep_version = "v00-06-02"
 
-DDMarlinPandora_version = "v00-12-02"
+DDMarlinPandora_version = "v00-13"
 
-MarlinReco_version = "v01-36-01"
+MarlinReco_version = "v01-36-02"
 
 FCalClusterer_version = "v01-00-06"
 
@@ -204,7 +204,7 @@ MarlinKinfit_version = "v00-06-01"
 
 MarlinKinfitProcessors_version = "v00-05"
 
-PandoraPFANew_version = "v04-12-00"
+PandoraPFANew_version = "v04-15-00"
 
 PandoraAnalysis_version = "v02-00-01"
 

--- a/releases/v02-03/release-versions.py
+++ b/releases/v02-03/release-versions.py
@@ -144,7 +144,7 @@ XERCESC_ROOT_DIR = ilcPath + "/xercesc/" + XercesC_version
 
 # -------------------------------------------
 
-LCIO_version = "v02-22-04"
+LCIO_version = "v02-22-05"
 
 GEAR_version = "v01-09-05"
 
@@ -230,10 +230,10 @@ DD4hepExamples_version = "v01-30"
 
 lcgeo_version = "v00-21"
 
-podio_version = "v01-01"
+podio_version = "v01-02"
 
 edm4hep_version = "v00-99-01"
 
-k4edm4hep2lcioconv_version = "v00-09"
+k4edm4hep2lcioconv_version = "v00-11"
 
 Physsim_version = "v00-05"

--- a/scripts/use_gcc131_cvmfs_el9.sh
+++ b/scripts/use_gcc131_cvmfs_el9.sh
@@ -14,3 +14,15 @@ export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-daa17/x86_64-el9
 
 # --- use a suitable mysql (also LCG_106)
 export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.5.20-7d082/x86_64-el9-gcc13-opt
+
+# --- pick up Qt5 from LCG release
+export CMAKE_PREFIX_PATH=/cvmfs/sft.cern.ch/lcg/releases/qt5/5.15.9-c981a/x86_64-el9-gcc13-opt:${CMAKE_PREFIX_PATH}
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/qt5/5.15.9-c981a/x86_64-el9-gcc13-opt/lib:${LD_LIBRARY_PATH}
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/qt5/5.15.9-c981a/x86_64-el9-gcc13-opt/bin:${PATH}
+export QT_PLUGIN_PATH=/cvmfs/sft.cern.ch/lcg/releases/qt5/5.15.9-c981a/x86_64-el9-gcc13-opt/plugins
+export QT_QMAKE_EXECUTABLE=/cvmfs/sft.cern.ch/lcg/releases/qt5/5.15.9-c981a/x86_64-el9-gcc13-opt/bin/qmake
+
+# --- also pick up xrootd from LCG release (as ROOT fails to build without this for whatever reason)
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/xrootd/5.6.9-2f3d3/x86_64-el9-gcc13-opt/bin:${PATH}
+export CMAKE_PREFIX_PATH=/cvmfs/sft.cern.ch/lcg/releases/xrootd/5.6.9-2f3d3/x86_64-el9-gcc13-opt:${CMAKE_PREFIX_PATH}
+export LD_PREFIX_PATH=/cvmfs/sft.cern.ch/lcg/releases/xrootd/5.6.9-2f3d3/x86_64-el9-gcc13-opt/lib64:${CMAKE_PREFIX_PATH}

--- a/scripts/use_gcc131_cvmfs_el9.sh
+++ b/scripts/use_gcc131_cvmfs_el9.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# --- gcc from LCG_106
+source /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/setup.sh
+
+# --- python from LCG_106
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/bin:${PATH}
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/lib:${LD_LIBRARY_PATH}
+export PYTHONPATH=/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/lib/python3.11/site-packages
+
+# --- git from LCG_106
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-daa17/x86_64-el9-gcc13-opt/bin:${PATH}
+export GIT_EXEC_PATH=/cvmfs/sft.cern.ch/lcg/releases/git/2.29.2-daa17/x86_64-el9-gcc13-opt/libexec/git-core
+
+# --- use a suitable mysql (also LCG_106)
+export MYSQL_DIR=/cvmfs/sft.cern.ch/lcg/releases/mysql/10.5.20-7d082/x86_64-el9-gcc13-opt

--- a/scripts/use_gcc131_cvmfs_el9.sh
+++ b/scripts/use_gcc131_cvmfs_el9.sh
@@ -5,7 +5,7 @@ source /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/setup.sh
 
 # --- python from LCG_106
 export PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/bin:${PATH}
-export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=/cvmfs/sft.cern.ch/lcg/releases/Python/3.11.9-2924c/x86_64-el9-gcc13-opt/lib:/cvmfs/sft.cern.ch/lcg/releases/blas/0.3.20.openblas-c07f1/x86_64-el9-gcc13-opt/lib:${LD_LIBRARY_PATH}
 export PYTHONPATH=/cvmfs/sft.cern.ch/lcg/views/LCG_106/x86_64-el9-gcc13-opt/lib/python3.11/site-packages
 
 # --- git from LCG_106


### PR DESCRIPTION
BEGINRELEASENOTES
- Create a first release on EL9 / Alma9
  - Using `gcc13`, `python3.11.9`
  - Switching to c++20
- Add Dockerfile to build CVMFS installation container
- Fix a few minor build issues in some packages
- Make all Marlin packages install their artifacts into `<prefix>/install` instead of only `<prefix>` to better separate the source code and the installed binaries
- Update packages to the following tags
  -  LCIO v02-22-05
  - Marlin v01-19-05
  - MarlinReco v01-36-02
  - MarlinUtil v01-18-02
  - k4geo (lcgeo) v00-21
  - DDMarlinPandora v00-13
  - MarlinTrkProcessors v02-12-07
  - iLCUtil v01-07-03
  - GEAR v01-09-05
  - CEDViewer v01-20
  - CED v01-10
  - KiTrack v01-10-01
  - LCFIPlus v00-11
  - PandoraPFANew v04-15-00

ENDRELEASENOTES

- [x] package versions to release notes
- [x] squash a few commits for a cleaner history to make rebase and merge make more sense
- [x] Test build