### PR TITLE
Bump python version for unittests

### DIFF
--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py_version: ['3.7']
+        py_version: ['3.12']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION

BEGINRELEASENOTES
- Bump python version from 3.7 to 3.12 to have unittests running in CI on latest ubuntu

ENDRELEASENOTES

@andresailer anything obvious that I might be missing here?